### PR TITLE
Add commonly-used filesystem helper to utils

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,19 +36,6 @@ if(BUILD_TESTING)
   ament_add_gtest(test_split test/test_split.cpp)
 
   ament_add_gtest(test_filesystem_helper test/test_filesystem_helper.cpp)
-
-  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_FLAGS MATCHES "-stdlib=libc\\+\\+")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
-      set(FILESYSTEM_LIB c++experimental)
-    else()
-      set(FILESYSTEM_LIB c++fs)
-    endif()
-  else()
-    set(FILESYSTEM_LIB stdc++fs)
-  endif()
-
-  target_link_libraries(test_filesystem_helper ${FILESYSTEM_LIB})
-
 endif()
 
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,21 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   ament_add_gtest(test_basic test/test_basic.cpp)
+
+  ament_add_gtest(test_filesystem_helper test/test_filesystem_helper.cpp)
+
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_FLAGS MATCHES "-stdlib=libc\\+\\+")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
+      set(FILESYSTEM_LIB c++experimental)
+    else()
+      set(FILESYSTEM_LIB c++fs)
+    endif()
+  else()
+    set(FILESYSTEM_LIB stdc++fs)
+  endif()
+
+  target_link_libraries(test_filesystem_helper ${FILESYSTEM_LIB})
+
 endif()
 
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_basic test/test_basic.cpp)
 
+  ament_add_gtest(test_split test/test_split.cpp)
+
   ament_add_gtest(test_filesystem_helper test/test_filesystem_helper.cpp)
 
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_FLAGS MATCHES "-stdlib=libc\\+\\+")

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -33,7 +33,7 @@
 // This file is originally from:
 // https://github.com/ros/pluginlib/blob/1a4de29fa55173e9b897ca8ff57ebc88c047e0b3/pluginlib/include/pluginlib/impl/filesystem_helper.hpp
 
-/// Includes std::filesystem and aliases the namespace to `pluginlib::impl::fs`.
+/// Includes std::filesystem and aliases the namespace to `rcpputils::fs`.
 /**
  * If std::filesystem is not available the necessary functions are emulated.
  */
@@ -73,8 +73,11 @@ public:
   {}
 
   path(const std::string & p)  // NOLINT(runtime/explicit): this is a conversion constructor
-  : path_(p), path_as_vector_(split(p, std::string(1, preferred_separator)))
-  {}
+  : path_(p), path_as_vector_(split(p, preferred_separator))
+  {
+    std::replace(path_.begin(), path_.end(), '\\', preferred_separator);
+    std::replace(path_.begin(), path_.end(), '/', preferred_separator);
+  }
 
   std::string string() const
   {

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -33,9 +33,11 @@
 // This file is originally from:
 // https://github.com/ros/pluginlib/blob/1a4de29fa55173e9b897ca8ff57ebc88c047e0b3/pluginlib/include/pluginlib/impl/filesystem_helper.hpp
 
-/// Includes std::filesystem and aliases the namespace to `rcpputils::fs`.
 /**
  * If std::filesystem is not available the necessary functions are emulated.
+ *
+ * Note: Once std::filesystem is supported on all ROS2 platforms, this class
+ * can be deprecated in favor of the built-in functionality.
  */
 
 #ifndef RCPPUTILS__FILESYSTEM_HELPER_HPP_

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, Open Source Robotics Foundation, Inc.
+// Copyright (c) 2019, Open Source Robotics Foundation, Inc.
 // All rights reserved.
 //
 // Software License Agreement (BSD License 2.0)
@@ -41,66 +41,28 @@
 #ifndef RCPPUTILS__FILESYSTEM_HELPER_HPP_
 #define RCPPUTILS__FILESYSTEM_HELPER_HPP_
 
-#if defined(_MSC_VER)
-# if _MSC_VER >= 1900
-#  include <experimental/filesystem>
-namespace rcpputils
-{
-namespace fs = std::experimental::filesystem;
-}  // namespace rcpputils
-
-#  define RCPPUTILS__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
-# endif
-
-#elif defined(__has_include)
-# if __has_include(< filesystem >) && __cplusplus >= 201703L
-#  include <filesystem>
-
-namespace rcpputils
-{
-namespace fs = std::filesystem;
-}  // namespace rcpputils
-
-#  define RCPPUTILS__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
-// cppcheck-suppress preprocessorErrorDirective
-# elif __has_include(< experimental / filesystem >)
-#  include <experimental/filesystem>
-
-namespace rcpputils
-{
-namespace fs = std::experimental::filesystem;
-}  // namespace rcpputils
-
-#  define RCPPUTILS__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
-# endif
-#endif
-
-// The standard library does not provide it, so emulate it.
-#ifndef RCPPUTILS__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
-
 #include <string>
 #include <vector>
 
 #ifdef _WIN32
-#define RCPPUTILS_IMPL_OS_DIRSEP '\\'
+#  define RCPPUTILS_IMPL_OS_DIRSEP '\\'
 #else
-#define RCPPUTILS_IMPL_OS_DIRSEP '/'
+#  define RCPPUTILS_IMPL_OS_DIRSEP '/'
 #endif
 
 #ifdef _WIN32
-  #include <io.h>
-  #define access _access_s
+#  include <io.h>
+#  define access _access_s
 #else
-  #include <unistd.h>
+#  include <unistd.h>
 #endif
 
-#include "./split.hpp"
+#include "rcpputils/split.hpp"
 
 namespace rcpputils
 {
 namespace fs
 {
-
 class path
 {
 public:
@@ -187,9 +149,5 @@ inline bool exists(const path & path_to_check)
 
 }  // namespace fs
 }  // namespace rcpputils
-
-#endif  // RCPPUTILS__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
-
-#undef RCPPUTILS__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
 
 #endif  // RCPPUTILS__FILESYSTEM_HELPER_HPP_

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -43,6 +43,7 @@
 #ifndef RCPPUTILS__FILESYSTEM_HELPER_HPP_
 #define RCPPUTILS__FILESYSTEM_HELPER_HPP_
 
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -65,20 +66,21 @@ namespace rcpputils
 {
 namespace fs
 {
+
+static constexpr const char kPreferredSeparator = RCPPUTILS_IMPL_OS_DIRSEP;
+
 class path
 {
 public:
-  static constexpr char preferred_separator = RCPPUTILS_IMPL_OS_DIRSEP;
-
   path()
   : path("")
   {}
 
   path(const std::string & p)  // NOLINT(runtime/explicit): this is a conversion constructor
-  : path_(p), path_as_vector_(split(p, preferred_separator))
+  : path_(p), path_as_vector_(split(p, kPreferredSeparator))
   {
-    std::replace(path_.begin(), path_.end(), '\\', preferred_separator);
-    std::replace(path_.begin(), path_.end(), '/', preferred_separator);
+    std::replace(path_.begin(), path_.end(), '\\', kPreferredSeparator);
+    std::replace(path_.begin(), path_.end(), '/', kPreferredSeparator);
   }
 
   std::string string() const
@@ -138,7 +140,7 @@ public:
 
   path & operator/=(const path & other)
   {
-    this->path_ += RCPPUTILS_IMPL_OS_DIRSEP + other.string();
+    this->path_ += kPreferredSeparator + other.string();
     this->path_as_vector_.insert(
       std::end(this->path_as_vector_),
       std::begin(other.path_as_vector_), std::end(other.path_as_vector_));

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -86,6 +86,11 @@ public:
     return access(path_.c_str(), 0) == 0;
   }
 
+  bool is_absolute() const
+  {
+    return path_.compare(0, 1, "/") == 0 || path_.compare(1, 2, ":\\") == 0;
+  }
+
   std::vector<std::string>::const_iterator cbegin() const
   {
     return path_as_vector_.cbegin();

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -1,0 +1,195 @@
+// Copyright (c) 2017, Open Source Robotics Foundation, Inc.
+// All rights reserved.
+//
+// Software License Agreement (BSD License 2.0)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//  * Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// This file is originally from:
+// https://github.com/ros/pluginlib/blob/1a4de29fa55173e9b897ca8ff57ebc88c047e0b3/pluginlib/include/pluginlib/impl/filesystem_helper.hpp
+
+/// Includes std::filesystem and aliases the namespace to `pluginlib::impl::fs`.
+/**
+ * If std::filesystem is not available the necessary functions are emulated.
+ */
+
+#ifndef RCPPUTILS__FILESYSTEM_HELPER_HPP_
+#define RCPPUTILS__FILESYSTEM_HELPER_HPP_
+
+#if defined(_MSC_VER)
+# if _MSC_VER >= 1900
+#  include <experimental/filesystem>
+namespace rcpputils
+{
+namespace fs = std::experimental::filesystem;
+}  // namespace rcpputils
+
+#  define RCPPUTILS__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
+# endif
+
+#elif defined(__has_include)
+# if __has_include(< filesystem >) && __cplusplus >= 201703L
+#  include <filesystem>
+
+namespace rcpputils
+{
+namespace fs = std::filesystem;
+}  // namespace rcpputils
+
+#  define RCPPUTILS__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
+// cppcheck-suppress preprocessorErrorDirective
+# elif __has_include(< experimental / filesystem >)
+#  include <experimental/filesystem>
+
+namespace rcpputils
+{
+namespace fs = std::experimental::filesystem;
+}  // namespace rcpputils
+
+#  define RCPPUTILS__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
+# endif
+#endif
+
+// The standard library does not provide it, so emulate it.
+#ifndef RCPPUTILS__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
+
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#define RCPPUTILS_IMPL_OS_DIRSEP '\\'
+#else
+#define RCPPUTILS_IMPL_OS_DIRSEP '/'
+#endif
+
+#ifdef _WIN32
+  #include <io.h>
+  #define access _access_s
+#else
+  #include <unistd.h>
+#endif
+
+#include "./split.hpp"
+
+namespace rcpputils
+{
+namespace fs
+{
+
+class path
+{
+public:
+  static constexpr char preferred_separator = RCPPUTILS_IMPL_OS_DIRSEP;
+
+  path()
+  : path("")
+  {}
+
+  path(const std::string & p)  // NOLINT(runtime/explicit): this is a conversion constructor
+  : path_(p), path_as_vector_(split(p, std::string(1, preferred_separator)))
+  {}
+
+  std::string string() const
+  {
+    return path_;
+  }
+
+  bool exists() const
+  {
+    return access(path_.c_str(), 0) == 0;
+  }
+
+  std::vector<std::string>::const_iterator cbegin() const
+  {
+    return path_as_vector_.cbegin();
+  }
+
+  std::vector<std::string>::const_iterator cend() const
+  {
+    return path_as_vector_.cend();
+  }
+
+  path parent_path() const
+  {
+    path parent("");
+    for (auto it = this->cbegin(); it != --this->cend(); ++it) {
+      parent /= *it;
+    }
+    return parent;
+  }
+
+  path filename() const
+  {
+    return path_.empty() ? path() : *--this->cend();
+  }
+
+  path operator/(const std::string & other)
+  {
+    return this->operator/(path(other));
+  }
+
+  path & operator/=(const std::string & other)
+  {
+    this->operator/=(path(other));
+    return *this;
+  }
+
+  path operator/(const path & other)
+  {
+    return path(*this).operator/=(other);
+  }
+
+  path & operator/=(const path & other)
+  {
+    this->path_ += RCPPUTILS_IMPL_OS_DIRSEP + other.string();
+    this->path_as_vector_.insert(
+      std::end(this->path_as_vector_),
+      std::begin(other.path_as_vector_), std::end(other.path_as_vector_));
+    return *this;
+  }
+
+private:
+  std::string path_;
+  std::vector<std::string> path_as_vector_;
+};
+
+inline bool exists(const path & path_to_check)
+{
+  return path_to_check.exists();
+}
+
+#undef RCPPUTILS_IMPL_OS_DIRSEP
+
+}  // namespace fs
+}  // namespace rcpputils
+
+#endif  // RCPPUTILS__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
+
+#undef RCPPUTILS__FILESYSYEM_HELPER__HAS_STD_FILESYSTEM
+
+#endif  // RCPPUTILS__FILESYSTEM_HELPER_HPP_

--- a/include/rcpputils/split.hpp
+++ b/include/rcpputils/split.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, Open Source Robotics Foundation, Inc.
+// Copyright (c) 2019, Open Source Robotics Foundation, Inc.
 // All rights reserved.
 //
 // Software License Agreement (BSD License 2.0)
@@ -36,37 +36,35 @@
 #ifndef RCPPUTILS__SPLIT_HPP_
 #define RCPPUTILS__SPLIT_HPP_
 
-#include <algorithm>
-#include <regex>
+#include <sstream>
 #include <string>
 #include <vector>
 
 namespace rcpputils
 {
 
-/// Split a specified input with a regular expression
+/// Split a specified input into tokens using a delimiter.
 /**
  * The returned vector will contain the tokens split from the input
  *
  * \param[in] input the input string to be split
- * \param[in] regex the regular expression to match to delimit tokens
+ * \param[in] delim the dlelimiter used to split the input string
  * \return A vector of tokens.
  */
 inline std::vector<std::string>
-split(const std::string & input, const std::string & regex, bool skip_empty = false)
+split(const std::string & input, char delim, bool skip_empty = false)
 {
-  std::regex re(regex);
-  // the -1 will cause this to return the stuff between the matches, see the submatch argument:
-  //   http://en.cppreference.com/w/cpp/regex/regex_token_iterator/regex_token_iterator
-  std::sregex_token_iterator first(input.begin(), input.end(), re, -1);
-  std::sregex_token_iterator last;
-
-  std::vector<std::string> ret;
-  std::copy_if(first, last, std::back_inserter(ret),
-    [skip_empty](std::string val) {
-      return !(skip_empty && val.empty());
-    });
-  return ret;
+  std::vector<std::string> result;
+  std::stringstream ss;
+  ss.str(input);
+  std::string item;
+  while (std::getline(ss, item, delim)) {
+    if (skip_empty && item == "") {
+      continue;
+    }
+    result.push_back(item);
+  }
+  return result;
 }
 }  // namespace rcpputils
 

--- a/include/rcpputils/split.hpp
+++ b/include/rcpputils/split.hpp
@@ -63,38 +63,11 @@ split(const std::string & input, const std::string & regex, bool skip_empty = fa
 
   std::vector<std::string> ret;
   std::copy_if(first, last, std::back_inserter(ret),
-      [skip_empty](std::string val){
-        return !(skip_empty && val.empty());
-      });
+    [skip_empty](std::string val) {
+      return !(skip_empty && val.empty());
+    });
   return ret;
 }
-
-/// Split a specified input with a delimited token
-/**
- * The returned vector will contain the tokens split from the input
- *
- * \param[in] input the input string to be split
- * \param[in] delim the delimiter used to split the string into tokens
- * \param[in] skip_empty True to remove empty tokens from the output
- * \return A vector of tokens.
- */
-inline std::vector<std::string>
-split(const std::string & s, char delim, bool skip_empty = false)
-{
-  std::vector<std::string> result;
-  std::stringstream ss;
-  ss.str(s);
-  std::string item;
-  while (std::getline(ss, item, delim)) {
-    if (skip_empty && item.empty() ) {
-      continue;
-    }
-    result.push_back(item);
-  }
-  return result;
-}
-
 }  // namespace rcpputils
 
 #endif  // RCPPUTILS__SPLIT_HPP_
-

--- a/include/rcpputils/split.hpp
+++ b/include/rcpputils/split.hpp
@@ -1,0 +1,100 @@
+// Copyright (c) 2017, Open Source Robotics Foundation, Inc.
+// All rights reserved.
+//
+// Software License Agreement (BSD License 2.0)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//  * Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// This file is originally from:
+// https://github.com/ros/pluginlib/blob/1a4de29fa55173e9b897ca8ff57ebc88c047e0b3/pluginlib/include/pluginlib/impl/split.hpp
+
+#ifndef RCPPUTILS__SPLIT_HPP_
+#define RCPPUTILS__SPLIT_HPP_
+
+#include <algorithm>
+#include <regex>
+#include <string>
+#include <vector>
+
+namespace rcpputils
+{
+
+/// Split a specified input with a regular expression
+/**
+ * The returned vector will contain the tokens split from the input
+ *
+ * \param[in] input the input string to be split
+ * \param[in] regex the regular expression to match to delimit tokens
+ * \return A vector of tokens.
+ */
+inline std::vector<std::string>
+split(const std::string & input, const std::string & regex, bool skip_empty = false)
+{
+  std::regex re(regex);
+  // the -1 will cause this to return the stuff between the matches, see the submatch argument:
+  //   http://en.cppreference.com/w/cpp/regex/regex_token_iterator/regex_token_iterator
+  std::sregex_token_iterator first(input.begin(), input.end(), re, -1);
+  std::sregex_token_iterator last;
+
+  std::vector<std::string> ret;
+  std::copy_if(first, last, std::back_inserter(ret),
+      [skip_empty](std::string val){
+        return !(skip_empty && val.empty());
+      });
+  return ret;
+}
+
+/// Split a specified input with a delimited token
+/**
+ * The returned vector will contain the tokens split from the input
+ *
+ * \param[in] input the input string to be split
+ * \param[in] delim the delimiter used to split the string into tokens
+ * \param[in] skip_empty True to remove empty tokens from the output
+ * \return A vector of tokens.
+ */
+inline std::vector<std::string>
+split(const std::string & s, char delim, bool skip_empty = false)
+{
+  std::vector<std::string> result;
+  std::stringstream ss;
+  ss.str(s);
+  std::string item;
+  while (std::getline(ss, item, delim)) {
+    if (skip_empty && item.empty() ) {
+      continue;
+    }
+    result.push_back(item);
+  }
+  return result;
+}
+
+}  // namespace rcpputils
+
+#endif  // RCPPUTILS__SPLIT_HPP_
+

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -80,4 +80,3 @@ TEST(TestFilesystemHelper, is_absolute)
     EXPECT_FALSE(p.is_absolute());
   }
 }
-

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -48,7 +48,23 @@ TEST(TestFilesystemHelper, to_native_path)
     }
   }
   {
+    auto p = path("\\foo\\bar\\baz");
+    if (is_win32) {
+      EXPECT_EQ("\\foo\\bar\\baz", p.string());
+    } else {
+      EXPECT_EQ("/foo/bar/baz", p.string());
+    }
+  }
+  {
     auto p = path("/foo//bar/baz");
+    if (is_win32) {
+      EXPECT_EQ("\\foo\\\\bar\\baz", p.string());
+    } else {
+      EXPECT_EQ("/foo//bar/baz", p.string());
+    }
+  }
+  {
+    auto p = path("\\foo\\\\bar\\baz");
     if (is_win32) {
       EXPECT_EQ("\\foo\\\\bar\\baz", p.string());
     } else {
@@ -59,24 +75,31 @@ TEST(TestFilesystemHelper, to_native_path)
 
 TEST(TestFilesystemHelper, is_absolute)
 {
-  {
-    auto p = path("/foo/bar/baz");
-    EXPECT_TRUE(p.is_absolute());
-  }
-  {
-    auto p = path("foo/bar/baz");
-    EXPECT_FALSE(p.is_absolute());
-  }
-  {
-    auto p = path("C:\\foo\\bar\\baz");
-    EXPECT_TRUE(p.is_absolute());
-  }
-  {
-    auto p = path("D:\\foo\\bar\\baz");
-    EXPECT_TRUE(p.is_absolute());
-  }
-  {
-    auto p = path("C:/foo/bar/baz");
-    EXPECT_FALSE(p.is_absolute());
+  if (is_win32) {
+    {
+      auto p = path("C:\\foo\\bar\\baz");
+      EXPECT_TRUE(p.is_absolute());
+    }
+    {
+      auto p = path("D:\\foo\\bar\\baz");
+      EXPECT_TRUE(p.is_absolute());
+    }
+    {
+      auto p = path("C:/foo/bar/baz");
+      EXPECT_TRUE(p.is_absolute());
+    }
+    {
+      auto p = path("foo/bar/baz");
+      EXPECT_FALSE(p.is_absolute());
+    }
+  } else {
+    {
+      auto p = path("/foo/bar/baz");
+      EXPECT_TRUE(p.is_absolute());
+    }
+    {
+      auto p = path("foo/bar/baz");
+      EXPECT_FALSE(p.is_absolute());
+    }
   }
 }

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -18,39 +18,41 @@
 
 #include "rcpputils/filesystem_helper.hpp"
 
+#ifdef WIN32
+static constexpr const bool is_win32 = true;
+#else
+static constexpr const bool is_win32 = false;
+#endif
+
 using path = rcpputils::fs::path;
 
 TEST(TestFilesystemHelper, join_path)
 {
   auto p = path("foo") / path("bar");
 
-#ifdef _WIN32
-  const char * ref_str = "foo\\bar";
-#else
-  const char * ref_str = "foo/bar";
-#endif  // _WIN32
-
-  EXPECT_STREQ(ref_str, p.string().c_str());
+  if (is_win32) {
+    EXPECT_EQ("foo\\bar", p.string());
+  } else {
+    EXPECT_EQ("foo/bar", p.string());
+  }
 }
 
 TEST(TestFilesystemHelper, to_native_path)
 {
   {
     auto p = path("/foo/bar/baz");
-#ifdef _WIN32
-    const char * ref_str = "\\foo\\bar\\baz";
-#else
-    const char * ref_str = "/foo/bar/baz";
-#endif  // _WIN32
-    EXPECT_STREQ(ref_str, p.string().c_str());
+    if (is_win32) {
+      EXPECT_EQ("\\foo\\bar\\baz", p.string());
+    } else {
+      EXPECT_EQ("/foo/bar/baz", p.string());
+    }
   }
   {
     auto p = path("/foo//bar/baz");
-#ifdef _WIN32
-    const char * ref_str = "\\foo\\\\bar\\baz";
-#else
-    const char * ref_str = "/foo//bar/baz";
-#endif  // _WIN32
-    EXPECT_STREQ(ref_str, p.string().c_str());
+    if (is_win32) {
+      EXPECT_EQ("\\foo\\\\bar\\baz", p.string());
+    } else {
+      EXPECT_EQ("/foo//bar/baz", p.string());
+    }
   }
 }

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -56,3 +56,28 @@ TEST(TestFilesystemHelper, to_native_path)
     }
   }
 }
+
+TEST(TestFilesystemHelper, is_absolute)
+{
+  {
+    auto p = path("/foo/bar/baz");
+    EXPECT_TRUE(p.is_absolute());
+  }
+  {
+    auto p = path("foo/bar/baz");
+    EXPECT_FALSE(p.is_absolute());
+  }
+  {
+    auto p = path("C:\\foo\\bar\\baz");
+    EXPECT_TRUE(p.is_absolute());
+  }
+  {
+    auto p = path("D:\\foo\\bar\\baz");
+    EXPECT_TRUE(p.is_absolute());
+  }
+  {
+    auto p = path("C:/foo/bar/baz");
+    EXPECT_FALSE(p.is_absolute());
+  }
+}
+

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -1,0 +1,56 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "rcpputils/filesystem_helper.hpp"
+
+using path = rcpputils::fs::path;
+
+TEST(TestFilesystemHelper, join_path)
+{
+  auto p = path("foo") / path("bar");
+
+#ifdef _WIN32
+  const char * ref_str = "foo\\bar";
+#else
+  const char * ref_str = "foo/bar";
+#endif  // _WIN32
+
+  EXPECT_STREQ(ref_str, p.string().c_str());
+}
+
+TEST(TestFilesystemHelper, to_native_path)
+{
+  {
+    auto p = path("/foo/bar/baz");
+#ifdef _WIN32
+    const char * ref_str = "\\foo\\bar\\baz";
+#else
+    const char * ref_str = "/foo/bar/baz";
+#endif  // _WIN32
+    EXPECT_STREQ(ref_str, p.string().c_str());
+  }
+  {
+    auto p = path("/foo//bar/baz");
+#ifdef _WIN32
+    const char * ref_str = "\\foo\\\\bar\\baz";
+#else
+    const char * ref_str = "/foo//bar/baz";
+#endif  // _WIN32
+    EXPECT_STREQ(ref_str, p.string().c_str());
+  }
+}

--- a/test/test_split.cpp
+++ b/test/test_split.cpp
@@ -1,0 +1,121 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "rcpputils/split.hpp"
+
+TEST(test_split, split_skip) {
+  {
+    auto ret = rcpputils::split("", "/", true);
+    EXPECT_EQ(0u, ret.size());
+  }
+  {
+    auto ret = rcpputils::split("", "/", false);
+    EXPECT_EQ(1u, ret.size());
+    EXPECT_EQ("", ret[0]);
+  }
+  {
+    auto ret = rcpputils::split("hello_world", "/", true);
+    EXPECT_EQ(1u, ret.size());
+    EXPECT_EQ("hello_world", ret[0]);
+  }
+  {
+    auto ret = rcpputils::split("hello_world", "/", false);
+    EXPECT_EQ(1u, ret.size());
+    EXPECT_EQ("hello_world", ret[0]);
+  }
+  {
+    auto ret = rcpputils::split("hello/world", "/", true);
+    EXPECT_EQ(2u, ret.size());
+    EXPECT_EQ("hello", ret[0]);
+    EXPECT_EQ("world", ret[1]);
+  }
+  {
+    auto ret = rcpputils::split("hello/world", "/", false);
+    EXPECT_EQ(2u, ret.size());
+    EXPECT_EQ("hello", ret[0]);
+    EXPECT_EQ("world", ret[1]);
+  }
+  {
+    auto ret = rcpputils::split("/hello/world", "/", true);
+    EXPECT_EQ(2u, ret.size());
+    EXPECT_EQ("hello", ret[0]);
+    EXPECT_EQ("world", ret[1]);
+  }
+  {
+    auto ret = rcpputils::split("/hello/world", "/", false);
+    EXPECT_EQ(3u, ret.size());
+    EXPECT_EQ("", ret[0]);
+    EXPECT_EQ("hello", ret[1]);
+    EXPECT_EQ("world", ret[2]);
+  }
+  {
+    auto ret = rcpputils::split("hello/world/", "/", true);
+    EXPECT_EQ(2u, ret.size());
+    EXPECT_EQ("hello", ret[0]);
+    EXPECT_EQ("world", ret[1]);
+  }
+  {
+    auto ret = rcpputils::split("hello/world/", "/", false);
+    EXPECT_EQ(2u, ret.size());
+    EXPECT_EQ("hello", ret[0]);
+    EXPECT_EQ("world", ret[1]);
+  }
+  {
+    auto ret = rcpputils::split("hello//world", "/", true);
+    EXPECT_EQ(2u, ret.size());
+    EXPECT_EQ("hello", ret[0]);
+    EXPECT_EQ("world", ret[1]);
+  }
+  {
+    auto ret = rcpputils::split("hello//world", "/", false);
+    EXPECT_EQ(3u, ret.size());
+    EXPECT_EQ("hello", ret[0]);
+    EXPECT_EQ("", ret[1]);
+    EXPECT_EQ("world", ret[2]);
+  }
+  {
+    auto ret = rcpputils::split("/my/hello/world", "/", true);
+    EXPECT_EQ(3u, ret.size());
+    EXPECT_EQ("my", ret[0]);
+    EXPECT_EQ("hello", ret[1]);
+    EXPECT_EQ("world", ret[2]);
+  }
+  {
+    auto ret = rcpputils::split("/my/hello/world", "/", false);
+    EXPECT_EQ(4u, ret.size());
+    EXPECT_EQ("", ret[0]);
+    EXPECT_EQ("my", ret[1]);
+    EXPECT_EQ("hello", ret[2]);
+    EXPECT_EQ("world", ret[3]);
+  }
+  {
+    auto ret = rcpputils::split("/my//hello//world/", "/", true);
+    EXPECT_EQ(3u, ret.size());
+    EXPECT_EQ("my", ret[0]);
+    EXPECT_EQ("hello", ret[1]);
+    EXPECT_EQ("world", ret[2]);
+  }
+  {
+    auto ret = rcpputils::split("/my//hello//world/", "/", false);
+    EXPECT_EQ(6u, ret.size());
+    EXPECT_EQ("", ret[0]);
+    EXPECT_EQ("my", ret[1]);
+    EXPECT_EQ("", ret[2]);
+    EXPECT_EQ("hello", ret[3]);
+    EXPECT_EQ("", ret[4]);
+    EXPECT_EQ("world", ret[5]);
+  }
+}

--- a/test/test_split.cpp
+++ b/test/test_split.cpp
@@ -16,85 +16,84 @@
 
 #include "rcpputils/split.hpp"
 
-TEST(test_split, split_skip) {
+TEST(test_split, split) {
   {
-    auto ret = rcpputils::split("", "/", true);
+    auto ret = rcpputils::split("", '/', true);
     EXPECT_EQ(0u, ret.size());
   }
   {
-    auto ret = rcpputils::split("", "/", false);
-    EXPECT_EQ(1u, ret.size());
-    EXPECT_EQ("", ret[0]);
+    auto ret = rcpputils::split("", '/', false);
+    EXPECT_EQ(0u, ret.size());
   }
   {
-    auto ret = rcpputils::split("hello_world", "/", true);
-    EXPECT_EQ(1u, ret.size());
-    EXPECT_EQ("hello_world", ret[0]);
-  }
-  {
-    auto ret = rcpputils::split("hello_world", "/", false);
+    auto ret = rcpputils::split("hello_world", '/', true);
     EXPECT_EQ(1u, ret.size());
     EXPECT_EQ("hello_world", ret[0]);
   }
   {
-    auto ret = rcpputils::split("hello/world", "/", true);
+    auto ret = rcpputils::split("hello_world", '/', false);
+    EXPECT_EQ(1u, ret.size());
+    EXPECT_EQ("hello_world", ret[0]);
+  }
+  {
+    auto ret = rcpputils::split("hello/world", '/', true);
     EXPECT_EQ(2u, ret.size());
     EXPECT_EQ("hello", ret[0]);
     EXPECT_EQ("world", ret[1]);
   }
   {
-    auto ret = rcpputils::split("hello/world", "/", false);
+    auto ret = rcpputils::split("hello/world", '/', false);
     EXPECT_EQ(2u, ret.size());
     EXPECT_EQ("hello", ret[0]);
     EXPECT_EQ("world", ret[1]);
   }
   {
-    auto ret = rcpputils::split("/hello/world", "/", true);
+    auto ret = rcpputils::split("/hello/world", '/', true);
     EXPECT_EQ(2u, ret.size());
     EXPECT_EQ("hello", ret[0]);
     EXPECT_EQ("world", ret[1]);
   }
   {
-    auto ret = rcpputils::split("/hello/world", "/", false);
+    auto ret = rcpputils::split("/hello/world", '/', false);
     EXPECT_EQ(3u, ret.size());
     EXPECT_EQ("", ret[0]);
     EXPECT_EQ("hello", ret[1]);
     EXPECT_EQ("world", ret[2]);
   }
   {
-    auto ret = rcpputils::split("hello/world/", "/", true);
+    auto ret = rcpputils::split("hello/world/", '/', true);
     EXPECT_EQ(2u, ret.size());
     EXPECT_EQ("hello", ret[0]);
     EXPECT_EQ("world", ret[1]);
   }
   {
-    auto ret = rcpputils::split("hello/world/", "/", false);
+    auto ret = rcpputils::split("hello/world/", '/', false);
     EXPECT_EQ(2u, ret.size());
     EXPECT_EQ("hello", ret[0]);
     EXPECT_EQ("world", ret[1]);
   }
   {
-    auto ret = rcpputils::split("hello//world", "/", true);
+    auto ret = rcpputils::split("hello//world", '/', true);
     EXPECT_EQ(2u, ret.size());
     EXPECT_EQ("hello", ret[0]);
     EXPECT_EQ("world", ret[1]);
   }
   {
-    auto ret = rcpputils::split("hello//world", "/", false);
+    auto ret = rcpputils::split("hello//world", '/', false);
     EXPECT_EQ(3u, ret.size());
     EXPECT_EQ("hello", ret[0]);
     EXPECT_EQ("", ret[1]);
     EXPECT_EQ("world", ret[2]);
   }
   {
-    auto ret = rcpputils::split("/my/hello/world", "/", true);
+    auto ret = rcpputils::split("/my/hello/world", '/', true);
     EXPECT_EQ(3u, ret.size());
     EXPECT_EQ("my", ret[0]);
     EXPECT_EQ("hello", ret[1]);
     EXPECT_EQ("world", ret[2]);
   }
   {
-    auto ret = rcpputils::split("/my/hello/world", "/", false);
+    auto ret = rcpputils::split("/my/hello/world", '/', false);
     EXPECT_EQ(4u, ret.size());
     EXPECT_EQ("", ret[0]);
     EXPECT_EQ("my", ret[1]);
@@ -102,14 +101,117 @@ TEST(test_split, split_skip) {
     EXPECT_EQ("world", ret[3]);
   }
   {
-    auto ret = rcpputils::split("/my//hello//world/", "/", true);
+    auto ret = rcpputils::split("/my//hello//world/", '/', true);
     EXPECT_EQ(3u, ret.size());
     EXPECT_EQ("my", ret[0]);
     EXPECT_EQ("hello", ret[1]);
     EXPECT_EQ("world", ret[2]);
   }
   {
-    auto ret = rcpputils::split("/my//hello//world/", "/", false);
+    auto ret = rcpputils::split("/my//hello//world/", '/', false);
+    EXPECT_EQ(6u, ret.size());
+    EXPECT_EQ("", ret[0]);
+    EXPECT_EQ("my", ret[1]);
+    EXPECT_EQ("", ret[2]);
+    EXPECT_EQ("hello", ret[3]);
+    EXPECT_EQ("", ret[4]);
+    EXPECT_EQ("world", ret[5]);
+  }
+}
+
+TEST(test_split, split_backslash) {
+  {
+    auto ret = rcpputils::split("", '\\', true);
+    EXPECT_EQ(0u, ret.size());
+  }
+  {
+    auto ret = rcpputils::split("", '\\', false);
+    EXPECT_EQ(0u, ret.size());
+  }
+  {
+    auto ret = rcpputils::split("hello_world", '\\', true);
+    EXPECT_EQ(1u, ret.size());
+    EXPECT_EQ("hello_world", ret[0]);
+  }
+  {
+    auto ret = rcpputils::split("hello_world", '\\', false);
+    EXPECT_EQ(1u, ret.size());
+    EXPECT_EQ("hello_world", ret[0]);
+  }
+  {
+    auto ret = rcpputils::split("hello\\world", '\\', true);
+    EXPECT_EQ(2u, ret.size());
+    EXPECT_EQ("hello", ret[0]);
+    EXPECT_EQ("world", ret[1]);
+  }
+  {
+    auto ret = rcpputils::split("hello\\world", '\\', false);
+    EXPECT_EQ(2u, ret.size());
+    EXPECT_EQ("hello", ret[0]);
+    EXPECT_EQ("world", ret[1]);
+  }
+  {
+    auto ret = rcpputils::split("\\hello\\world", '\\', true);
+    EXPECT_EQ(2u, ret.size());
+    EXPECT_EQ("hello", ret[0]);
+    EXPECT_EQ("world", ret[1]);
+  }
+  {
+    auto ret = rcpputils::split("\\hello\\world", '\\', false);
+    EXPECT_EQ(3u, ret.size());
+    EXPECT_EQ("", ret[0]);
+    EXPECT_EQ("hello", ret[1]);
+    EXPECT_EQ("world", ret[2]);
+  }
+  {
+    auto ret = rcpputils::split("hello\\world\\", '\\', true);
+    EXPECT_EQ(2u, ret.size());
+    EXPECT_EQ("hello", ret[0]);
+    EXPECT_EQ("world", ret[1]);
+  }
+  {
+    auto ret = rcpputils::split("hello\\world\\", '\\', false);
+    EXPECT_EQ(2u, ret.size());
+    EXPECT_EQ("hello", ret[0]);
+    EXPECT_EQ("world", ret[1]);
+  }
+  {
+    auto ret = rcpputils::split("hello\\\\world", '\\', true);
+    EXPECT_EQ(2u, ret.size());
+    EXPECT_EQ("hello", ret[0]);
+    EXPECT_EQ("world", ret[1]);
+  }
+  {
+    auto ret = rcpputils::split("hello\\\\world", '\\', false);
+    EXPECT_EQ(3u, ret.size());
+    EXPECT_EQ("hello", ret[0]);
+    EXPECT_EQ("", ret[1]);
+    EXPECT_EQ("world", ret[2]);
+  }
+  {
+    auto ret = rcpputils::split("\\my\\hello\\world", '\\', true);
+    EXPECT_EQ(3u, ret.size());
+    EXPECT_EQ("my", ret[0]);
+    EXPECT_EQ("hello", ret[1]);
+    EXPECT_EQ("world", ret[2]);
+  }
+  {
+    auto ret = rcpputils::split("\\my\\hello\\world", '\\', false);
+    EXPECT_EQ(4u, ret.size());
+    EXPECT_EQ("", ret[0]);
+    EXPECT_EQ("my", ret[1]);
+    EXPECT_EQ("hello", ret[2]);
+    EXPECT_EQ("world", ret[3]);
+  }
+  {
+    auto ret = rcpputils::split("\\my\\\\hello\\\\world\\", '\\', true);
+    EXPECT_EQ(3u, ret.size());
+    EXPECT_EQ("my", ret[0]);
+    EXPECT_EQ("hello", ret[1]);
+    EXPECT_EQ("world", ret[2]);
+  }
+  {
+    auto ret = rcpputils::split("\\my\\\\hello\\\\world\\", '\\', false);
     EXPECT_EQ(6u, ret.size());
     EXPECT_EQ("", ret[0]);
     EXPECT_EQ("my", ret[1]);


### PR DESCRIPTION
This is a file that is used in pluginlib, but could be convenient to have in other places. 

It includes the appropriate location for `std::filesystem` if it is supported, otherwise it has a small `path` object that implements the most basic functionality. 

https://github.com/ros/pluginlib/blob/1a4de29fa55173e9b897ca8ff57ebc88c047e0b3/pluginlib/include/pluginlib/impl/filesystem_helper.hpp

Connects to ros2/rclcpp#665