### PR TITLE
Fix thread_safety_annotation filename to .hpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,10 @@ This package currently contains:
 *   Clang thread safety annotation macros
 
 ## Clang Thread Safety Annotation Macros
-the `rcpputils/thread_safety_annotations.h` header provides macros for Clang's [Thread Safety Analysis](https://clang.llvm.org/docs/ThreadSafetyAnalysis.html) feature.
+the `rcpputils/thread_safety_annotations.hpp` header provides macros for Clang's [Thread Safety Analysis](https://clang.llvm.org/docs/ThreadSafetyAnalysis.html) feature.
 
 The macros allow you to annotate your code, but expand to nothing when using a non-clang compiler, so they are safe for cross-platform use.
 
-To use thread safety annotation in your package (in the Clang build only), enable the `-Wthread-safety` compiler flag, and include the header
-
-```
-#include "rcpputils/thread_safety_annotations.h"
-```
+To use thread safety annotation in your package (in a Clang+libcxx build), enable the `-Wthread-safety` compiler flag.
 
 For example usage, see [the documentation of this feature](https://clang.llvm.org/docs/ThreadSafetyAnalysis.html) and the tests in `test/test_basic.cpp`

--- a/include/rcpputils/thread_safety_annotations.hpp
+++ b/include/rcpputils/thread_safety_annotations.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RCPPUTILS__THREAD_SAFETY_ANNOTATIONS_H_
-#define RCPPUTILS__THREAD_SAFETY_ANNOTATIONS_H_
+#ifndef RCPPUTILS__THREAD_SAFETY_ANNOTATIONS_HPP_
+#define RCPPUTILS__THREAD_SAFETY_ANNOTATIONS_HPP_
 
 #include <mutex>
 
@@ -97,4 +97,4 @@ inline const std::mutex & operator!(const std::mutex & a)
 #define RCPPUTILS_TSA_NO_THREAD_SAFETY_ANALYSIS \
   RCPPUTILS_THREAD_ANNOTATION_ATTRIBUTE__(no_thread_safety_analysis)
 
-#endif  // RCPPUTILS__THREAD_SAFETY_ANNOTATIONS_H_
+#endif  // RCPPUTILS__THREAD_SAFETY_ANNOTATIONS_HPP_

--- a/test/test_basic.cpp
+++ b/test/test_basic.cpp
@@ -14,7 +14,7 @@
 
 #include "gtest/gtest.h"
 
-#include "rcpputils/thread_safety_annotations.h"
+#include "rcpputils/thread_safety_annotations.hpp"
 
 /*
 Macros tested


### PR DESCRIPTION
Signed-off-by: Emerson Knapp <eknapp@amazon.com>