### PR TITLE
0.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,13 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package rcpputils
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.1.0 (2019-04-13)
+------------------
+* Fixed leak in test_basic.cpp. (`#9 <https://github.com/ros2/rcpputils/issues/9>`_)
+* Added CODEOWNERS file. (`#10 <https://github.com/ros2/rcpputils/issues/10>`_)
+* Added commonly-used filesystem helper to utils. (`#5 <https://github.com/ros2/rcpputils/issues/5>`_)
+* Fixed thread_safety_annotation filename to .hpp. (`#6 <https://github.com/ros2/rcpputils/issues/6>`_)
+* Added section about DCO to CONTRIBUTING.md.
+* Added thread annotation macros. (`#2 <https://github.com/ros2/rcpputils/issues/2>`_)
+* Contributors: Dirk Thomas, Emerson Knapp, Michael Carroll, Thomas Moulard


### PR DESCRIPTION
This is a replacement for https://github.com/ros2/rcpputils/pull/11 which doesn't change the commit hash.