### PR TITLE
use iterators for split

### DIFF
--- a/include/rcpputils/split.hpp
+++ b/include/rcpputils/split.hpp
@@ -36,12 +36,42 @@
 #ifndef RCPPUTILS__SPLIT_HPP_
 #define RCPPUTILS__SPLIT_HPP_
 
+#include <iterator>
 #include <sstream>
 #include <string>
 #include <vector>
 
 namespace rcpputils
 {
+
+/// Split a specified input into tokens using a delimiter and a type erased insert iterator.
+/**
+ * The returned vector will contain the tokens split from the input
+ *
+ * \param[in] input the input string to be split
+ * \param[in] delim the dlelimiter used to split the input string
+ * \param[in] insert iterator pointing to a storage contianer
+ */
+template<
+  class InsertIterator,
+  typename std::enable_if<
+    std::is_same<
+      InsertIterator &,
+      decltype(std::declval<InsertIterator>().operator=(std::declval<std::string>()))>::value
+  >::type * = nullptr>
+inline void
+split(const std::string & input, char delim, InsertIterator & it, bool skip_empty = false)
+{
+  std::stringstream ss;
+  ss.str(input);
+  std::string item;
+  while (std::getline(ss, item, delim)) {
+    if (skip_empty && item == "") {
+      continue;
+    }
+    it = item;
+  }
+}
 
 /// Split a specified input into tokens using a delimiter.
 /**
@@ -55,15 +85,8 @@ inline std::vector<std::string>
 split(const std::string & input, char delim, bool skip_empty = false)
 {
   std::vector<std::string> result;
-  std::stringstream ss;
-  ss.str(input);
-  std::string item;
-  while (std::getline(ss, item, delim)) {
-    if (skip_empty && item == "") {
-      continue;
-    }
-    result.push_back(item);
-  }
+  auto it = std::back_inserter(result);
+  split(input, delim, it, skip_empty);
   return result;
 }
 }  // namespace rcpputils

--- a/include/rcpputils/split.hpp
+++ b/include/rcpputils/split.hpp
@@ -50,7 +50,7 @@ namespace rcpputils
  *
  * \param[in] input the input string to be split
  * \param[in] delim the dlelimiter used to split the input string
- * \param[in] insert iterator pointing to a storage contianer
+ * \param[in] insert iterator pointing to a storage container
  */
 template<
   class InsertIterator,
@@ -59,7 +59,7 @@ template<
       InsertIterator &,
       decltype(std::declval<InsertIterator>().operator=(std::declval<std::string>()))>::value
   >::type * = nullptr>
-inline void
+void
 split(const std::string & input, char delim, InsertIterator & it, bool skip_empty = false)
 {
   std::stringstream ss;

--- a/test/test_split.cpp
+++ b/test/test_split.cpp
@@ -229,7 +229,7 @@ TEST(test_split, split_backslash) {
   }
 }
 
-TEST(test_split, iterator)
+TEST(test_split, vector_iterator)
 {
   std::string s = "my/hello/world";
 
@@ -239,14 +239,23 @@ TEST(test_split, iterator)
   EXPECT_EQ("my", vec[0]);
   EXPECT_EQ("hello", vec[1]);
   EXPECT_EQ("world", vec[2]);
+}
+
+TEST(test_split, list_iterator)
+{
+  std::string s = "my/hello/world";
 
   std::list<std::string> ll = {};
   auto ll_it = std::back_inserter(ll);
   rcpputils::split(s, '/', ll_it);
   EXPECT_EQ("my", ll.front());
   EXPECT_EQ("world", ll.back());
+}
 
-  s = "wonderful string with wonderful duplicates duplicates";
+TEST(test_split, set_iterator)
+{
+  std::string s = "wonderful string with wonderful duplicates duplicates";
+
   std::set<std::string> set = {};
   auto set_it = std::inserter(set, std::begin(set));
   rcpputils::split(s, ' ', set_it);
@@ -297,4 +306,11 @@ TEST(test_split, custom_iterator)
   EXPECT_STREQ("MyMessage", triple_it.message_name.c_str());
 
   EXPECT_EQ(std::make_tuple("my_pkg", "msg", "MyMessage"), triple_it.get());
+}
+
+TEST(test_split, custom_iterator_exception)
+{
+  std::string s = "my_pkg/msg/MyMessage/Wrong";
+  TripleExtractor triple_it;
+  ASSERT_THROW(rcpputils::split(s, '/', triple_it), std::out_of_range);
 }


### PR DESCRIPTION
I am extending the current split implementation for a iterator based design. This allows to use the same functionality for split to be used in different containers (e.g. `std::list`, `std::set`) and gives the opportunity for custom iterators. Especially the latter seems quite useful in order to correctly split and parse a message definition and extract it as a tuple.

CI: (build: up-to rcpputils, test: packages-select rcpputils)
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7342)](http://ci.ros2.org/job/ci_linux/7342/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=3507)](http://ci.ros2.org/job/ci_linux-aarch64/3507/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6020)](http://ci.ros2.org/job/ci_osx/6020/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7163)](http://ci.ros2.org/job/ci_windows/7163/)

Signed-off-by: Karsten Knese <karsten@openrobotics.org>