### PR TITLE
Add endian helper until C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,8 @@ if(BUILD_TESTING)
   ament_add_gtest(test_filesystem_helper test/test_filesystem_helper.cpp)
 
   ament_add_gtest(test_find_and_replace test/test_find_and_replace.cpp)
+
+  ament_add_gtest(test_endian test/test_endian.cpp)
 endif()
 
 ament_package()

--- a/include/rcpputils/endian.hpp
+++ b/include/rcpputils/endian.hpp
@@ -1,0 +1,50 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * If std::endian is not available, the necessary functions are emulated.
+ *
+ * Note: Once std::endian is supported on all ROS2 platforms, this class
+ * can be deprecated in favor of the built-in functionality.
+ *
+ * Note: std::endian is targeted for C++20
+ */
+
+#ifndef RCPPUTILS__ENDIAN_HPP_
+#define RCPPUTILS__ENDIAN_HPP_
+
+#ifdef __has_include
+#  if __has_include(<endian.h>)
+#    include <endian.h>
+#  endif
+#endif
+
+namespace rcpputils
+{
+// Ref: https://en.cppreference.com/w/cpp/types/endian#Possible_implementation
+enum class endian
+{
+#ifdef _WIN32
+  little = 0,
+  big    = 1,
+  native = little
+#else
+  little = __ORDER_LITTLE_ENDIAN__,
+  big    = __ORDER_BIG_ENDIAN__,
+  native = __BYTE_ORDER__
+#endif
+};
+}  // namespace rcpputils
+
+#endif  // RCPPUTILS__ENDIAN_HPP_

--- a/include/rcpputils/endian.hpp
+++ b/include/rcpputils/endian.hpp
@@ -33,6 +33,8 @@
 namespace rcpputils
 {
 // Ref: https://en.cppreference.com/w/cpp/types/endian#Possible_implementation
+// From: https://en.cppreference.com/w/Cppreference:FAQ, this is licensed
+// Creative Commons Attribution-Sharealike 3.0 Unported License (CC-BY-SA)
 enum class endian
 {
 #ifdef _WIN32

--- a/include/rcpputils/endian.hpp
+++ b/include/rcpputils/endian.hpp
@@ -24,6 +24,21 @@
 #ifndef RCPPUTILS__ENDIAN_HPP_
 #define RCPPUTILS__ENDIAN_HPP_
 
+// TODO(anyone) replace this macro when the appropriate C++20 value lands.
+#if !defined(RCPPUTILS_NO_STD_ENDIAN) && (__cplusplus <= 201703L)
+#define RCPPUTILS_NO_STD_ENDIAN
+#endif
+
+#if !defined(RCPPUTILS_NO_STD_ENDIAN)
+#include <type_traits>
+namespace rcpputils
+{
+using std::endian;
+}  // namespace rcpputils
+#define RCPPUTILS_HAVE_STD_ENDIAN 1
+#endif  // __cplusplus > 201703L
+
+#ifndef RCPPUTILS_HAVE_STD_ENDIAN
 #ifdef __has_include
 #  if __has_include(<endian.h>)
 #    include <endian.h>
@@ -48,5 +63,5 @@ enum class endian
 #endif
 };
 }  // namespace rcpputils
-
+#endif  // RCPPUTILS_HAVE_STD_ENDIAN
 #endif  // RCPPUTILS__ENDIAN_HPP_

--- a/test/test_endian.cpp
+++ b/test/test_endian.cpp
@@ -1,0 +1,47 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gtest/gtest.h"
+
+#include "rcpputils/endian.hpp"
+
+// Basic runtime endianness check
+bool isLittleEndian()
+{
+  uint16_t number = 0x0001;
+  uint8_t * numPtr = reinterpret_cast<uint8_t *>(&number);
+  return numPtr[0] == 1;
+}
+
+TEST(test_endian, is_defined)
+{
+  // A platform should be one or other other
+  EXPECT_TRUE((rcpputils::endian::little == rcpputils::endian::native) ||
+    (rcpputils::endian::big == rcpputils::endian::native));
+}
+
+TEST(test_endian, runtime_endianness)
+{
+  // Compare the runtime evaluation to the predefined constant value.
+  EXPECT_TRUE(isLittleEndian() &&
+    rcpputils::endian::little == rcpputils::endian::native);
+}
+
+#ifdef _WIN32
+// Windows is always little-endian
+TEST(test_endian, win32)
+{
+  EXPECT_TRUE(rcpputils::endian::little == rcpputils::endian::native);
+}
+#endif

--- a/test/test_endian.cpp
+++ b/test/test_endian.cpp
@@ -36,6 +36,20 @@ TEST(test_endian, runtime_endianness)
   // Compare the runtime evaluation to the predefined constant value.
   EXPECT_TRUE(isLittleEndian() &&
     rcpputils::endian::little == rcpputils::endian::native);
+
+  if (rcpputils::endian::little == rcpputils::endian::native) {
+    std::cout << "Compiler reports: little endian" << std::endl;
+  } else if (rcpputils::endian::big == rcpputils::endian::native) {
+    std::cout << "Compiler reports: big endian" << std::endl;
+  } else {
+    std::cout << "Compiler reports: mixed/unknown endian" << std::endl;
+  }
+
+  if(isLittleEndian()) {
+    std::cout << "Runtime reports: little endian" << std::endl;
+  } else {
+    std::cout << "Runtime reports: big endian" << std::endl;
+  }
 }
 
 #ifdef _WIN32

--- a/test/test_endian.cpp
+++ b/test/test_endian.cpp
@@ -26,7 +26,7 @@ bool isLittleEndian()
 
 TEST(test_endian, is_defined)
 {
-  // A platform should be one or other other
+  // A platform should be one or other.
   EXPECT_TRUE((rcpputils::endian::little == rcpputils::endian::native) ||
     (rcpputils::endian::big == rcpputils::endian::native));
 }
@@ -53,11 +53,3 @@ TEST(test_endian, runtime_endianness)
     std::cout << "Runtime reports: big endian" << std::endl;
   }
 }
-
-#ifdef _WIN32
-// Windows is always little-endian
-TEST(test_endian, win32)
-{
-  EXPECT_TRUE(rcpputils::endian::little == rcpputils::endian::native);
-}
-#endif

--- a/test/test_endian.cpp
+++ b/test/test_endian.cpp
@@ -33,19 +33,21 @@ TEST(test_endian, is_defined)
 
 TEST(test_endian, runtime_endianness)
 {
-  // Compare the runtime evaluation to the predefined constant value.
-  EXPECT_TRUE(isLittleEndian() &&
-    rcpputils::endian::little == rcpputils::endian::native);
+  bool littleEndian = rcpputils::endian::little == rcpputils::endian::native;
+  bool bigEndian = rcpputils::endian::big == rcpputils::endian::native;
 
-  if (rcpputils::endian::little == rcpputils::endian::native) {
+  EXPECT_EQ(isLittleEndian(), littleEndian);
+  EXPECT_EQ(!isLittleEndian(), bigEndian);
+
+  if (littleEndian && !bigEndian) {
     std::cout << "Compiler reports: little endian" << std::endl;
-  } else if (rcpputils::endian::big == rcpputils::endian::native) {
+  } else if (!littleEndian && bigEndian) {
     std::cout << "Compiler reports: big endian" << std::endl;
   } else {
     std::cout << "Compiler reports: mixed/unknown endian" << std::endl;
   }
 
-  if(isLittleEndian()) {
+  if (isLittleEndian()) {
     std::cout << "Runtime reports: little endian" << std::endl;
   } else {
     std::cout << "Runtime reports: big endian" << std::endl;


### PR DESCRIPTION
std::endian won't exist until C++20, and this helps remove a dependency on boost::endian in the meantime.