### PR TITLE
type trait rcpputils::is_pointer<T>`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_find_and_replace test/test_find_and_replace.cpp)
 
+  ament_add_gtest(test_pointer_traits test/test_pointer_traits.cpp)
+
   ament_add_gtest(test_endian test/test_endian.cpp)
 endif()
 

--- a/include/rcpputils/pointer_traits.hpp
+++ b/include/rcpputils/pointer_traits.hpp
@@ -1,0 +1,76 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCPPUTILS__POINTER_TRAITS_HPP_
+#define RCPPUTILS__POINTER_TRAITS_HPP_
+
+#include <memory>
+#include <type_traits>
+
+namespace rcpputils
+{
+
+namespace details
+{
+
+template<class T>
+struct is_smart_pointer_helper : std::false_type
+{};
+
+template<class T>
+struct is_smart_pointer_helper<std::shared_ptr<T>>: std::true_type
+{};
+
+template<class T>
+struct is_smart_pointer_helper<std::unique_ptr<T>>: std::true_type
+{};
+
+template<class T>
+struct is_smart_pointer : is_smart_pointer_helper<typename std::remove_cv<T>::type>
+{};
+
+}  // namespace details
+
+/// Type traits for validating if T is of type pointer
+/**
+ * In comparison to the existing type trait for pointer in the stdlib `std::is_pointer<T>`
+ * https://en.cppreference.com/w/cpp/types/is_pointer this trait is enhancing it for
+ * checking of smart pointer types as well.
+ * The valid pointer types are T*, std::smart_pointer<T> and std::unique_ptr<T>
+ *
+ * Potential use cases are for static assert when passing a template parameter requiring this
+ * parameter to be of type pointer without specifying which type of pointer (raw, smart).
+ *
+ * ```
+ * class MyType
+ * {
+ *   template<class T>
+ *   MyType(T && arg)
+ *   {
+ *     static_assert(rcpputils::is_pointer<decltype(arg)>::value, "arg has to be a pointer");
+ *
+ *     arg->do_stuff();  // with the assert above, this call is guaranteed to work.
+ *   }
+ * };
+ * ```
+ */
+template<class T>
+struct is_pointer
+{
+  static constexpr bool value = std::is_pointer<T>::value || details::is_smart_pointer<T>::value;
+};
+
+}  // namespace rcpputils
+
+#endif  // RCPPUTILS__POINTER_TRAITS_HPP_

--- a/test/test_pointer_traits.cpp
+++ b/test/test_pointer_traits.cpp
@@ -1,0 +1,75 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <memory>
+
+#include "rcpputils/pointer_traits.hpp"
+
+TEST(TestPointerTraits, is_pointer) {
+  auto ptr = new int(13);
+  const auto * const cptrc = new int(13);
+  auto sptr = std::make_shared<int>(13);
+  const auto csptr = std::make_shared<int>(13);
+  const volatile auto cvsptr = std::make_shared<int>(13);
+  const volatile auto cvsptrc = std::shared_ptr<int const>(cptrc);
+  auto uptr = std::make_unique<int>(13);
+  const auto cuptr = std::make_unique<int>(13);
+  const volatile auto cvuptr = std::make_unique<int>(13);
+  const volatile auto cvuptrc = std::make_unique<const int>(13);
+
+  auto b_ptr = rcpputils::is_pointer<decltype(ptr)>::value;
+  auto b_cptrc = rcpputils::is_pointer<decltype(cptrc)>::value;
+  auto b_sptr = rcpputils::is_pointer<decltype(sptr)>::value;
+  auto b_csptr = rcpputils::is_pointer<decltype(csptr)>::value;
+  auto b_cvsptr = rcpputils::is_pointer<decltype(cvsptr)>::value;
+  auto b_cvsptrc = rcpputils::is_pointer<decltype(cvsptrc)>::value;
+  auto b_uptr = rcpputils::is_pointer<decltype(uptr)>::value;
+  auto b_cuptr = rcpputils::is_pointer<decltype(cuptr)>::value;
+  auto b_cvuptr = rcpputils::is_pointer<decltype(cvuptr)>::value;
+  auto b_cvuptrc = rcpputils::is_pointer<decltype(cvuptrc)>::value;
+
+  EXPECT_TRUE(b_ptr);
+  EXPECT_TRUE(b_cptrc);
+  EXPECT_TRUE(b_sptr);
+  EXPECT_TRUE(b_csptr);
+  EXPECT_TRUE(b_cvsptr);
+  EXPECT_TRUE(b_cvsptrc);
+  EXPECT_TRUE(b_uptr);
+  EXPECT_TRUE(b_cuptr);
+  EXPECT_TRUE(b_cvuptr);
+  EXPECT_TRUE(b_cvuptrc);
+}
+
+struct POD
+{
+  int i = 0;
+  bool b = false;
+};
+
+TEST(TestPointerTraits, is_no_pointer) {
+  int i = 13;
+  std::string s = "hello world";
+  POD pod;
+
+  auto b_i = rcpputils::is_pointer<decltype(i)>::value;
+  auto b_s = rcpputils::is_pointer<decltype(s)>::value;
+  auto b_pod = rcpputils::is_pointer<decltype(pod)>::value;
+
+  EXPECT_FALSE(b_i);
+  EXPECT_FALSE(b_s);
+  EXPECT_FALSE(b_pod);
+}


### PR DESCRIPTION
Moving the PR https://github.com/ros2/rclcpp/pull/817 over to `rcpputils`.

I hopefully addressed previous feedback about adding documentation to it. Please let me know if the documentation is sufficient or if more details should be provided.

Signed-off-by: Karsten Knese <karsten@openrobotics.org>