### PR TITLE
Add new function to remove the extension of a file

### DIFF
--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -137,15 +137,23 @@ public:
     return split_fname.size() == 1 ? path("") : path("." + split_fname.back());
   }
 
-  path remove_extension(int n_times = 1)
+  /**
+   * Remove extension(s) from a path. An extension is defined as text starting from the end of a 
+   * path to the first period (.) character.
+   *
+   * \param n_times The number of extensions to remove if there are multiple extensions.
+   * \return The path object.
+   */
+  path & remove_extension(int n_times = 1)
   {
     for (int i = 0; i < n_times; i++) {
       size_t last_dot = path_.find_last_of('.');
       if (last_dot == std::string::npos) {
-        return path(path_);
+        return *this;
       }
-      return path(path_.erase(last_dot, path_.size() - 1));
+      path_.erase(last_dot, path_.size() - 1);
     }
+    return *this;
   }
 
   path operator/(const std::string & other)

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -195,8 +195,6 @@ inline bool create_directories(const path & p)
   return true;
 }
 
-#undef RCPPUTILS_IMPL_OS_DIRSEP
-
 /**
  * Remove extension(s) from a path. An extension is defined as text starting from the end of a
  * path to the first period (.) character.
@@ -205,7 +203,7 @@ inline bool create_directories(const path & p)
  * \param n_times The number of extensions to remove if there are multiple extensions.
  * \return The path object.
  */
-path remove_extension(const path & file_path, int n_times = 1)
+inline path remove_extension(const path & file_path, int n_times = 1)
 {
   path new_path(file_path);
   for (int i = 0; i < n_times; i++) {
@@ -218,6 +216,8 @@ path remove_extension(const path & file_path, int n_times = 1)
   }
   return new_path;
 }
+
+#undef RCPPUTILS_IMPL_OS_DIRSEP
 
 }  // namespace fs
 }  // namespace rcpputils

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -72,6 +72,11 @@ namespace fs
 
 static constexpr const char kPreferredSeparator = RCPPUTILS_IMPL_OS_DIRSEP;
 
+/**
+ * path is meant to be a drop-in replacement of https://en.cppreference.com/w/cpp/filesystem/path.
+ * It must conform to the same standard described and cannot include methods that are not 
+ * incorporated there.
+ */
 class path
 {
 public:
@@ -137,25 +142,6 @@ public:
     return split_fname.size() == 1 ? path("") : path("." + split_fname.back());
   }
 
-  /**
-   * Remove extension(s) from a path. An extension is defined as text starting from the end of a 
-   * path to the first period (.) character.
-   *
-   * \param n_times The number of extensions to remove if there are multiple extensions.
-   * \return The path object.
-   */
-  path & remove_extension(int n_times = 1)
-  {
-    for (int i = 0; i < n_times; i++) {
-      size_t last_dot = path_.find_last_of('.');
-      if (last_dot == std::string::npos) {
-        return *this;
-      }
-      path_.erase(last_dot, path_.size() - 1);
-    }
-    return *this;
-  }
-
   path operator/(const std::string & other)
   {
     return this->operator/(path(other));
@@ -208,6 +194,27 @@ inline bool create_directories(const path & p)
 }
 
 #undef RCPPUTILS_IMPL_OS_DIRSEP
+
+/**
+ * Remove extension(s) from a path. An extension is defined as text starting from the end of a 
+ * path to the first period (.) character.
+ *
+ * \param file_path The file path string.
+ * \param n_times The number of extensions to remove if there are multiple extensions.
+ * \return The path object.
+ */
+path remove_extension(const path & file_path, int n_times = 1)
+{
+  path new_path = path(file_path);
+  for (int i = 0; i < n_times; i++) {
+    size_t last_dot = new_path.string().find_last_of('.');
+    if (last_dot == std::string::npos) {
+      return new_path;
+    }
+    new_path = path(new_path.string().substr(0, last_dot));
+  }
+  return new_path;
+}
 
 }  // namespace fs
 }  // namespace rcpputils

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -137,6 +137,17 @@ public:
     return split_fname.size() == 1 ? path("") : path("." + split_fname.back());
   }
 
+  path remove_extension(int n_times = 1)
+  {
+    for (int i = 0; i < n_times; i++) {
+      size_t last_dot = path_.find_last_of('.');
+      if (last_dot == std::string::npos) {
+        return path(path_);
+      }
+      return path(path_.erase(last_dot, path_.size() - 1));
+    }
+  }
+
   path operator/(const std::string & other)
   {
     return this->operator/(path(other));

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -91,6 +91,8 @@ public:
     std::replace(path_.begin(), path_.end(), '/', kPreferredSeparator);
   }
 
+  path(const path & p) = default;
+
   std::string string() const
   {
     return path_;
@@ -205,13 +207,14 @@ inline bool create_directories(const path & p)
  */
 path remove_extension(const path & file_path, int n_times = 1)
 {
-  path new_path = path(file_path);
+  path new_path(file_path);
   for (int i = 0; i < n_times; i++) {
-    size_t last_dot = new_path.string().find_last_of('.');
+    const auto new_path_str = new_path.string();
+    const auto last_dot = new_path_str.find_last_of('.');
     if (last_dot == std::string::npos) {
       return new_path;
     }
-    new_path = path(new_path.string().substr(0, last_dot));
+    new_path = path(new_path_str.substr(0, last_dot));
   }
   return new_path;
 }

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -74,7 +74,7 @@ static constexpr const char kPreferredSeparator = RCPPUTILS_IMPL_OS_DIRSEP;
 
 /**
  * path is meant to be a drop-in replacement of https://en.cppreference.com/w/cpp/filesystem/path.
- * It must conform to the same standard described and cannot include methods that are not 
+ * It must conform to the same standard described and cannot include methods that are not
  * incorporated there.
  */
 class path
@@ -196,7 +196,7 @@ inline bool create_directories(const path & p)
 #undef RCPPUTILS_IMPL_OS_DIRSEP
 
 /**
- * Remove extension(s) from a path. An extension is defined as text starting from the end of a 
+ * Remove extension(s) from a path. An extension is defined as text starting from the end of a
  * path to the first period (.) character.
  *
  * \param file_path The file path string.

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -160,3 +160,31 @@ TEST(TestFilesystemHelper, create_directories)
   auto p = path(build_directory_path());
   EXPECT_TRUE(rcpputils::fs::create_directories(p));
 }
+
+TEST(TestFilesystemHelper, remove_extension)
+{
+  auto p = path("foo.txt");
+  p.remove_extension();
+  EXPECT_EQ("foo", p.string());
+}
+
+TEST(TestFilesystemHelper, remove_extensions)
+{
+  auto p = path("foo.txt.compress");
+  p.remove_extension(2);
+  EXPECT_EQ("foo", p.string());
+}
+
+TEST(TestFilesystemHelper, remove_extensions_overcount)
+{
+  auto p = path("foo.txt.compress");
+  p.remove_extension(4);
+  EXPECT_EQ("foo", p.string());
+}
+
+TEST(TestFilesystemHelper, remove_extension_no_extension)
+{
+  auto p = path("foo");
+  p.remove_extension();
+  EXPECT_EQ("foo", p.string());
+}

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -164,27 +164,27 @@ TEST(TestFilesystemHelper, create_directories)
 TEST(TestFilesystemHelper, remove_extension)
 {
   auto p = path("foo.txt");
-  p.remove_extension();
+  p = rcpputils::fs::remove_extension(p.string());
   EXPECT_EQ("foo", p.string());
 }
 
 TEST(TestFilesystemHelper, remove_extensions)
 {
   auto p = path("foo.txt.compress");
-  p.remove_extension(2);
+  p = rcpputils::fs::remove_extension(p, 2);
   EXPECT_EQ("foo", p.string());
 }
 
 TEST(TestFilesystemHelper, remove_extensions_overcount)
 {
   auto p = path("foo.txt.compress");
-  p.remove_extension(4);
+  p = rcpputils::fs::remove_extension(p, 4);
   EXPECT_EQ("foo", p.string());
 }
 
 TEST(TestFilesystemHelper, remove_extension_no_extension)
 {
   auto p = path("foo");
-  p.remove_extension();
+  p = rcpputils::fs::remove_extension(p);
   EXPECT_EQ("foo", p.string());
 }


### PR DESCRIPTION
Part of the changes being introduced to `ros2/rosbag2` is removing the extension of a file's URI.
It would be nice to have this part of the filesystem_helper library.

Signed-off-by: Anas Abou Allaban <allabana@amazon.com>