### PR TITLE
Fix filesystem helpers for directory manipulation.

### DIFF
--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -182,8 +182,8 @@ inline bool exists(const path & path_to_check)
 inline bool create_directories(const path & p)
 {
   path p_built;
-
   int status = 0;
+
   for (auto it = p.cbegin(); it != p.cend() && status == 0; ++it) {
     if (p_built.empty()) {
       p_built = *it;

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -183,16 +183,31 @@ inline bool create_directories(const path & p)
 {
   path p_built;
 
-  for (auto it = p.cbegin(); it != p.cend(); ++it) {
-    p_built /= *it;
-
+  int status = 0;
+  for (auto it = p.cbegin(); it != p.cend() && status == 0; ++it) {
+    if (p_built.empty()) {
+      p_built = *it;
+    } else {
+      p_built /= *it;
+    }
+    if (!p_built.exists()) {
 #ifdef _WIN32
-    _mkdir(p_built.string().c_str());
+      status = _mkdir(p_built.string().c_str());
 #else
-    mkdir(p_built.string().c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+      status = mkdir(p_built.string().c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
 #endif
+    }
   }
-  return true;
+  return status == 0;
+}
+
+inline bool remove(const path & p)
+{
+#ifdef _WIN32
+  return _rmdir(p.string().c_str()) == 0;
+#else
+  return rmdir(p.string().c_str()) == 0;
+#endif
 }
 
 /**

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -150,15 +150,20 @@ TEST(TestFilesystemHelper, is_empty)
 }
 
 /**
- * Test create directories.
+ * Test directory manipulation API.
  *
  * NOTE: expects the current directory to be write-only, else test will fail.
  *
  */
-TEST(TestFilesystemHelper, create_directories)
+TEST(TestFilesystemHelper, directory_manipulation)
 {
   auto p = path(build_directory_path());
+  (void)rcpputils::fs::remove(p);
+  EXPECT_FALSE(rcpputils::fs::exists(p));
   EXPECT_TRUE(rcpputils::fs::create_directories(p));
+  EXPECT_TRUE(rcpputils::fs::exists(p));
+  EXPECT_TRUE(rcpputils::fs::remove(p));
+  EXPECT_FALSE(rcpputils::fs::exists(p));
 }
 
 TEST(TestFilesystemHelper, remove_extension)

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include <fstream>
 #include <string>
 
 #include "rcpputils/filesystem_helper.hpp"
@@ -150,20 +151,26 @@ TEST(TestFilesystemHelper, is_empty)
 }
 
 /**
- * Test directory manipulation API.
+ * Test filesystem manipulation API.
  *
  * NOTE: expects the current directory to be write-only, else test will fail.
  *
  */
-TEST(TestFilesystemHelper, directory_manipulation)
+TEST(TestFilesystemHelper, filesystem_manipulation)
 {
-  auto p = path(build_directory_path());
-  (void)rcpputils::fs::remove(p);
-  EXPECT_FALSE(rcpputils::fs::exists(p));
-  EXPECT_TRUE(rcpputils::fs::create_directories(p));
-  EXPECT_TRUE(rcpputils::fs::exists(p));
-  EXPECT_TRUE(rcpputils::fs::remove(p));
-  EXPECT_FALSE(rcpputils::fs::exists(p));
+  auto dir = path(build_directory_path());
+  (void)rcpputils::fs::remove(dir);
+  EXPECT_FALSE(rcpputils::fs::exists(dir));
+  EXPECT_TRUE(rcpputils::fs::create_directories(dir));
+  EXPECT_TRUE(rcpputils::fs::exists(dir));
+  auto file = dir / "test_file.txt";
+  std::ofstream(file.string()) << "test";
+  EXPECT_TRUE(rcpputils::fs::exists(file));
+  EXPECT_FALSE(rcpputils::fs::remove(dir));
+  EXPECT_TRUE(rcpputils::fs::remove(file));
+  EXPECT_TRUE(rcpputils::fs::remove(dir));
+  EXPECT_FALSE(rcpputils::fs::exists(file));
+  EXPECT_FALSE(rcpputils::fs::exists(dir));
 }
 
 TEST(TestFilesystemHelper, remove_extension)


### PR DESCRIPTION
Precisely what the title says. Also added a partial `std::filesystem::remove()` equivalent for `rcpputils::fs::create_directories()` testing purposes.