### PR TITLE
Add functions for C++ assertions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ include_directories(include)
 ament_export_include_directories(include)
 
 add_library(${PROJECT_NAME}
+  src/asserts.cpp
   src/find_library.cpp)
 target_include_directories(${PROJECT_NAME}
   PUBLIC
@@ -47,10 +48,12 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   ament_add_gtest(test_asserts_ndebug test/test_asserts.cpp)
+  target_link_libraries(test_asserts_ndebug ${PROJECT_NAME})
 
   target_compile_definitions(test_asserts_ndebug PUBLIC NDEBUG)
 
   ament_add_gtest(test_asserts_debug test/test_asserts.cpp)
+  target_link_libraries(test_asserts_debug ${PROJECT_NAME})
 
   ament_add_gtest(test_thread_safety_annotations test/test_thread_safety_annotations.cpp)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,9 +48,7 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_asserts_ndebug test/test_asserts.cpp)
 
-  if(TARGET test_asserts_ndebug)
-    add_definitions(-DNDEBUG)
-  endif()
+  target_compile_definitions(test_asserts_ndebug PUBLIC NDEBUG)
 
   ament_add_gtest(test_asserts_debug test/test_asserts.cpp)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,14 @@ if(BUILD_TESTING)
 
   ament_lint_auto_find_test_dependencies()
 
+  ament_add_gtest(test_asserts_ndebug test/test_asserts.cpp)
+
+  if(TARGET test_asserts_ndebug)
+    add_definitions(-DNDEBUG)
+  endif()
+
+  ament_add_gtest(test_asserts_debug test/test_asserts.cpp)
+
   ament_add_gtest(test_thread_safety_annotations test/test_thread_safety_annotations.cpp)
 
   ament_add_gtest(test_join test/test_join.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,9 @@ if(BUILD_TESTING)
   ament_add_gtest(test_asserts_ndebug test/test_asserts.cpp)
   target_link_libraries(test_asserts_ndebug ${PROJECT_NAME})
 
-  target_compile_definitions(test_asserts_ndebug PUBLIC NDEBUG)
+  if(TARGET test_asserts_ndebug)
+    target_compile_definitions(test_asserts_ndebug PUBLIC NDEBUG)
+  endif()
 
   ament_add_gtest(test_asserts_debug test/test_asserts.cpp)
   target_link_libraries(test_asserts_debug ${PROJECT_NAME})

--- a/include/rcpputils/asserts.hpp
+++ b/include/rcpputils/asserts.hpp
@@ -25,7 +25,7 @@ namespace rcpputils
  * \param condition
  * \throw std::runtime_error if the condition is not met.
  */
-inline void check(bool condition)
+inline void check_true(bool condition)
 {
   if (!condition) {
     throw std::runtime_error{"Check reported invalid state!"};
@@ -39,7 +39,7 @@ inline void check(bool condition)
  * \param condition
  * \throw std::runtime_error if the macro NDEBUG is not set and the condition is not met.
  */
-inline void ros_assert(bool condition)
+inline void assert_true(bool condition)
 {
 // Same macro definition used by cassert
 #ifndef NDEBUG

--- a/include/rcpputils/asserts.hpp
+++ b/include/rcpputils/asserts.hpp
@@ -15,20 +15,44 @@
 #ifndef RCPPUTILS__ASSERTS_HPP_
 #define RCPPUTILS__ASSERTS_HPP_
 
-#include <stdexcept>
+#include <exception>
+#include <string>
 
 namespace rcpputils
 {
+
+class AssertionException : public std::exception
+{
+  std::string msg_;
+
+public:
+  explicit AssertionException(const std::string & msg)
+  : msg_{msg} {}
+
+  virtual const char * what() const throw();
+};
+
+class IllegalStateException : public std::exception
+{
+  std::string msg_;
+
+public:
+  explicit IllegalStateException(const std::string & msg)
+  : msg_{msg} {}
+
+  virtual const char * what() const throw();
+};
+
 /**
  * Checks that a state condition passes.
  *
  * \param condition
- * \throw std::runtime_error if the condition is not met.
+ * \throw rcpputils::IllegalStateException if the condition is not met.
  */
 inline void check_true(bool condition)
 {
   if (!condition) {
-    throw std::runtime_error{"Check reported invalid state!"};
+    throw rcpputils::IllegalStateException{"Check reported invalid state!"};
   }
 }
 
@@ -37,14 +61,14 @@ inline void check_true(bool condition)
  *
  * This function behaves similar to assert, except that it throws instead of invoking abort().
  * \param condition
- * \throw std::runtime_error if the macro NDEBUG is not set and the condition is not met.
+ * \throw rcpputils::AssertionException if the macro NDEBUG is not set and the condition is not met.
  */
 inline void assert_true(bool condition)
 {
 // Same macro definition used by cassert
 #ifndef NDEBUG
   if (!condition) {
-    throw std::runtime_error{"Assertion failed!"};
+    throw rcpputils::AssertionException{"Assertion failed!"};
   }
 #else
   (void) condition;

--- a/include/rcpputils/asserts.hpp
+++ b/include/rcpputils/asserts.hpp
@@ -26,6 +26,7 @@
 // This should be fine since its extending an STL class.
 #ifdef _WIN32
 # pragma warning(push)
+# pragma warning(disable:4251)
 # pragma warning(disable:4275)
 #endif
 
@@ -37,8 +38,7 @@ class RCPPUTILS_PUBLIC AssertionException : public std::exception
   std::string msg_;
 
 public:
-  explicit AssertionException(const std::string & msg)
-  : msg_{msg} {}
+  explicit AssertionException(const char * msg);
 
   virtual const char * what() const throw();
 };
@@ -48,8 +48,7 @@ class RCPPUTILS_PUBLIC IllegalStateException : public std::exception
   std::string msg_;
 
 public:
-  explicit IllegalStateException(const std::string & msg)
-  : msg_{msg} {}
+  explicit IllegalStateException(const char * msg);
 
   virtual const char * what() const throw();
 };
@@ -99,5 +98,9 @@ inline void assert_true(bool condition)
 #endif
 }
 }  // namespace rcpputils
+
+#ifdef _WIN32
+# pragma warning(pop)
+#endif
 
 #endif  // RCPPUTILS__ASSERTS_HPP_

--- a/include/rcpputils/asserts.hpp
+++ b/include/rcpputils/asserts.hpp
@@ -1,0 +1,55 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCPPUTILS__ASSERTS_HPP_
+#define RCPPUTILS__ASSERTS_HPP_
+
+#include <stdexcept>
+
+namespace rcpputils
+{
+/**
+ * Checks that a state condition passes.
+ *
+ * \param condition
+ * \throw std::runtime_error if the condition is not met.
+ */
+inline void check(bool condition)
+{
+  if (!condition) {
+    throw std::runtime_error{"Check reported invalid state!"};
+  }
+}
+
+/**
+ * Asserts that a condition passes.
+ *
+ * This function behaves similar to assert, except that it throws instead of invoking abort().
+ * \param condition
+ * \throw std::runtime_error if the macro NDEBUG is not set and the condition is not met.
+ */
+inline void ros_assert(bool condition)
+{
+// Same macro definition used by cassert
+#ifndef NDEBUG
+  if (!condition) {
+    throw std::runtime_error{"Assertion failed!"};
+  }
+#else
+  (void) condition;
+#endif
+}
+}  // namespace rcpputils
+
+#endif  // RCPPUTILS__ASSERTS_HPP_

--- a/include/rcpputils/asserts.hpp
+++ b/include/rcpputils/asserts.hpp
@@ -19,10 +19,12 @@
 #include <stdexcept>
 #include <string>
 
+#include "rcpputils/visibility_control.hpp"
+
 namespace rcpputils
 {
 
-class AssertionException : public std::exception
+class RCPPUTILS_PUBLIC AssertionException : public std::exception
 {
   std::string msg_;
 
@@ -33,7 +35,7 @@ public:
   virtual const char * what() const throw();
 };
 
-class IllegalStateException : public std::exception
+class RCPPUTILS_PUBLIC IllegalStateException : public std::exception
 {
   std::string msg_;
 

--- a/include/rcpputils/asserts.hpp
+++ b/include/rcpputils/asserts.hpp
@@ -16,6 +16,7 @@
 #define RCPPUTILS__ASSERTS_HPP_
 
 #include <exception>
+#include <stdexcept>
 #include <string>
 
 namespace rcpputils
@@ -42,6 +43,19 @@ public:
 
   virtual const char * what() const throw();
 };
+
+/**
+ * Checks that an argument condition passes.
+ *
+ * \param condition
+ * \throw std::invalid_argument if the condition is not met.
+ */
+inline void require_true(bool condition)
+{
+  if (!condition) {
+    throw std::invalid_argument{"Invalid argument passed!"};
+  }
+}
 
 /**
  * Checks that a state condition passes.

--- a/include/rcpputils/asserts.hpp
+++ b/include/rcpputils/asserts.hpp
@@ -21,6 +21,14 @@
 
 #include "rcpputils/visibility_control.hpp"
 
+// Needed to disable compiler warning for exporting a class that extends a
+// non-DLL-interface class.
+// This should be fine since its extending an STL class.
+#ifdef _WIN32
+# pragma warning(push)
+# pragma warning(disable:4275)
+#endif
+
 namespace rcpputils
 {
 

--- a/src/asserts.cpp
+++ b/src/asserts.cpp
@@ -16,9 +16,19 @@
 
 namespace rcpputils
 {
+AssertionException::AssertionException(const char * msg)
+{
+  msg_ = msg;
+}
+
 const char * AssertionException::what() const throw()
 {
   return msg_.c_str();
+}
+
+IllegalStateException::IllegalStateException(const char * msg)
+{
+  msg_ = msg;
 }
 
 const char * IllegalStateException::what() const throw()

--- a/src/asserts.cpp
+++ b/src/asserts.cpp
@@ -1,0 +1,28 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rcpputils/asserts.hpp"
+
+namespace rcpputils
+{
+const char * AssertionException::what() const throw()
+{
+  return msg_.c_str();
+}
+
+const char * IllegalStateException::what() const throw()
+{
+  return msg_.c_str();
+}
+}  // namespace rcpputils

--- a/test/test_asserts.cpp
+++ b/test/test_asserts.cpp
@@ -19,26 +19,26 @@
 #include "rcpputils/asserts.hpp"
 
 TEST(test_asserts, check_throws_if_condition_is_false) {
-  EXPECT_THROW(rcpputils::check(false), std::runtime_error);
+  EXPECT_THROW(rcpputils::check_true(false), std::runtime_error);
 }
 
 TEST(test_asserts, check_does_not_throw_if_condition_is_true) {
-  EXPECT_NO_THROW(rcpputils::check(true));
+  EXPECT_NO_THROW(rcpputils::check_true(true));
 }
 
 #ifndef NDEBUG
 TEST(test_asserts, ros_assert_throws_if_condition_is_false_and_ndebug_not_set) {
-  EXPECT_THROW(rcpputils::ros_assert(false), std::runtime_error);
+  EXPECT_THROW(rcpputils::assert_true(false), std::runtime_error);
 }
 
 TEST(test_asserts, ros_assert_does_not_throw_if_condition_is_true_and_ndebug_not_set)
 {
-  EXPECT_NO_THROW(rcpputils::ros_assert(true));
+  EXPECT_NO_THROW(rcpputils::assert_true(true));
 }
 
 #else
 TEST(test_asserts, ros_assert_does_not_throw_if_ndebug_set) {
-  EXPECT_NO_THROW(rcpputils::ros_assert(false));
-  EXPECT_NO_THROW(rcpputils::ros_assert(true));
+  EXPECT_NO_THROW(rcpputils::assert_true(false));
+  EXPECT_NO_THROW(rcpputils::assert_true(true));
 }
 #endif

--- a/test/test_asserts.cpp
+++ b/test/test_asserts.cpp
@@ -19,7 +19,7 @@
 #include "rcpputils/asserts.hpp"
 
 TEST(test_asserts, check_throws_if_condition_is_false) {
-  EXPECT_THROW(rcpputils::check_true(false), std::runtime_error);
+  EXPECT_THROW(rcpputils::check_true(false), rcpputils::IllegalStateException);
 }
 
 TEST(test_asserts, check_does_not_throw_if_condition_is_true) {
@@ -28,7 +28,7 @@ TEST(test_asserts, check_does_not_throw_if_condition_is_true) {
 
 #ifndef NDEBUG
 TEST(test_asserts, ros_assert_throws_if_condition_is_false_and_ndebug_not_set) {
-  EXPECT_THROW(rcpputils::assert_true(false), std::runtime_error);
+  EXPECT_THROW(rcpputils::assert_true(false), rcpputils::AssertionException);
 }
 
 TEST(test_asserts, ros_assert_does_not_throw_if_condition_is_true_and_ndebug_not_set)

--- a/test/test_asserts.cpp
+++ b/test/test_asserts.cpp
@@ -18,6 +18,14 @@
 
 #include "rcpputils/asserts.hpp"
 
+TEST(test_asserts, require_throws_if_condition_is_false) {
+  EXPECT_THROW(rcpputils::require_true(false), std::invalid_argument);
+}
+
+TEST(test_asserts, require_does_not_throw_if_condition_is_true) {
+  EXPECT_NO_THROW(rcpputils::require_true(true));
+}
+
 TEST(test_asserts, check_throws_if_condition_is_false) {
   EXPECT_THROW(rcpputils::check_true(false), rcpputils::IllegalStateException);
 }

--- a/test/test_asserts.cpp
+++ b/test/test_asserts.cpp
@@ -1,0 +1,44 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdexcept>
+
+#include "gtest/gtest.h"
+
+#include "rcpputils/asserts.hpp"
+
+TEST(test_asserts, check_throws_if_condition_is_false) {
+  EXPECT_THROW(rcpputils::check(false), std::runtime_error);
+}
+
+TEST(test_asserts, check_does_not_throw_if_condition_is_true) {
+  EXPECT_NO_THROW(rcpputils::check(true));
+}
+
+#ifndef NDEBUG
+TEST(test_asserts, ros_assert_throws_if_condition_is_false_and_ndebug_not_set) {
+  EXPECT_THROW(rcpputils::ros_assert(false), std::runtime_error);
+}
+
+TEST(test_asserts, ros_assert_does_not_throw_if_condition_is_true_and_ndebug_not_set)
+{
+  EXPECT_NO_THROW(rcpputils::ros_assert(true));
+}
+
+#else
+TEST(test_asserts, ros_assert_does_not_throw_if_ndebug_set) {
+  EXPECT_NO_THROW(rcpputils::ros_assert(false));
+  EXPECT_NO_THROW(rcpputils::ros_assert(true));
+}
+#endif


### PR DESCRIPTION
### Changes
* Add `rcpputils::require_true(condition)` which throws `std::invalid_argument` if condition is false. Its indended use is for parameter checks that should always be ran.
* Add `rcpputils::check_true(condition)` which throws `rcpputils::InvalidStateException` if condition is false. Its intended use is for state checks that should always be ran.
* Add `rcpputils::assert_true(condition)` which throws `rcpputils::AssertionException` if condition is false AND the macro`NDEBUG` is not set. Its intended use is for additional checks inserted into debug builds.

### Issues
* Feature requested here: https://github.com/ros2/rcpputils/issues/29