### PR TITLE
Add build and test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Test rcpputils
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  schedule:
+    # Run every hour. This helps detect flakiness,
+    # and broken external dependencies.
+    - cron:  '0 * * * *'
+
+jobs:
+  build_and_test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+          os: [ubuntu-18.04]
+    steps:
+    - uses: ros-tooling/setup-ros@0.0.13
+    - uses: ros-tooling/action-ros-ci@0.0.13
+      with:
+        package-name: rcpputils
+    - uses: actions/upload-artifact@master
+      with:
+        name: colcon-logs
+        path: ros2_ws/log

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,4 +24,4 @@ jobs:
     - uses: actions/upload-artifact@master
       with:
         name: colcon-logs
-        path: ros2_ws/log
+        path: ros_ws/log


### PR DESCRIPTION
### Changes
* Add GH Actions workflow to run build and test hourly, on pull requests, and merge into master.

### Notes
* GH Actions are currently failing due to Azure sync.
* This PR is mirrored on [this fork](https://github.com/aws-ros-dev/rcpputils/pull/2) to show that the action properly works.

Signed-off-by: Zachary Michaels <zmichaels11@gmail.com>