### PR TITLE
Bug fixes for rcpputils::fs API

### DIFF
--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -127,9 +127,13 @@ public:
 
   path parent_path() const
   {
-    path parent("");
+    path parent;
     for (auto it = this->cbegin(); it != --this->cend(); ++it) {
-      parent /= *it;
+      if (!parent.empty() || it->empty()) {
+        parent /= *it;
+      } else {
+        parent = *it;
+      }
     }
     return parent;
   }

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -54,6 +54,7 @@
 #endif
 
 #ifdef _WIN32
+#  include <windows.h>
 #  include <direct.h>
 #  include <fileapi.h>
 #  include <io.h>

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -190,7 +190,8 @@ inline path temp_directory_path()
   TCHAR temp_path[MAX_PATH];
   DWORD size = GetTempPathA(MAX_PATH, temp_path);
   if (size > MAX_PATH || size == 0) {
-    throw std::system_error("cannot get temporary directory path");
+    std::error_code ec(static_cast<int>(GetLastError()), std::system_category());
+    throw std::system_error(ec, "cannot get temporary directory path");
   }
   temp_path[size] = '\0';
 #else

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -187,8 +187,8 @@ inline path temp_directory_path()
 #ifdef UNICODE
 #error "rcpputils::fs does not support Unicode paths"
 #endif
-  char temp_path[MAX_PATH];
-  int size = GetTempPathA(MAX_PATH, &temp_path);
+  TCHAR temp_path[MAX_PATH];
+  DWORD size = GetTempPathA(MAX_PATH, temp_path);
   if (size > MAX_PATH || size == 0) {
     throw std::system_error("cannot get temporary directory path");
   }

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -58,6 +58,13 @@ TEST(TestFilesystemHelper, join_path)
   }
 }
 
+TEST(TestFilesystemHelper, parent_path)
+{
+  auto p = path("my") / path("path");
+
+  EXPECT_EQ(p.parent_path().string(), path("my").string());
+}
+
 TEST(TestFilesystemHelper, to_native_path)
 {
   {

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -171,6 +171,13 @@ TEST(TestFilesystemHelper, filesystem_manipulation)
   EXPECT_TRUE(rcpputils::fs::remove(dir));
   EXPECT_FALSE(rcpputils::fs::exists(file));
   EXPECT_FALSE(rcpputils::fs::exists(dir));
+  auto temp_dir = rcpputils::fs::temp_directory_path();
+  temp_dir = temp_dir / "rcpputils" / "test_folder";
+  EXPECT_FALSE(rcpputils::fs::exists(temp_dir));
+  EXPECT_TRUE(rcpputils::fs::create_directories(temp_dir));
+  EXPECT_TRUE(rcpputils::fs::exists(temp_dir));
+  EXPECT_TRUE(rcpputils::fs::remove(temp_dir));
+  EXPECT_TRUE(rcpputils::fs::remove(temp_dir.parent_path()));
 }
 
 TEST(TestFilesystemHelper, remove_extension)


### PR DESCRIPTION
Follow up after https://github.com/ros2/rcpputils/pull/30. Using absolute paths would make `rcpputils::fs::create_directories` fail otherwise. It also introduces a `temp_directory_path()` implementation solely for testing the aforementioned patch.

Edit: well, it turns out the `parent_path()` method was also broken.

CI up to `rcpputils`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9210)](http://ci.ros2.org/job/ci_linux/9210/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4875)](http://ci.ros2.org/job/ci_linux-aarch64/4875/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=7478)](http://ci.ros2.org/job/ci_osx/7478/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9125)](http://ci.ros2.org/job/ci_windows/9125/)