### PR TITLE
code style only: wrap after open parenthesis if not in one line

### DIFF
--- a/test/test_endian.cpp
+++ b/test/test_endian.cpp
@@ -27,7 +27,8 @@ bool isLittleEndian()
 TEST(test_endian, is_defined)
 {
   // A platform should be one or other.
-  EXPECT_TRUE((rcpputils::endian::little == rcpputils::endian::native) ||
+  EXPECT_TRUE(
+    (rcpputils::endian::little == rcpputils::endian::native) ||
     (rcpputils::endian::big == rcpputils::endian::native));
 }
 


### PR DESCRIPTION
Style update to match the ROS 2 development guide and pass with the updated linter configuration from ament/ament_lint#210.