### PR TITLE
remove reference for pointer traits

### DIFF
--- a/include/rcpputils/pointer_traits.hpp
+++ b/include/rcpputils/pointer_traits.hpp
@@ -68,7 +68,8 @@ struct is_smart_pointer : is_smart_pointer_helper<typename std::remove_cv<T>::ty
 template<class T>
 struct is_pointer
 {
-  static constexpr bool value = std::is_pointer<T>::value || details::is_smart_pointer<T>::value;
+  static constexpr bool value = std::is_pointer<typename std::remove_reference<T>::type>::value ||
+    details::is_smart_pointer<typename std::remove_reference<T>::type>::value;
 };
 
 }  // namespace rcpputils

--- a/test/test_pointer_traits.cpp
+++ b/test/test_pointer_traits.cpp
@@ -21,6 +21,7 @@
 
 TEST(TestPointerTraits, is_pointer) {
   auto ptr = new int(13);
+  auto ptr_ptr = &ptr;
   const auto * const cptrc = new int(13);
   auto sptr = std::make_shared<int>(13);
   const auto csptr = std::make_shared<int>(13);
@@ -32,6 +33,8 @@ TEST(TestPointerTraits, is_pointer) {
   const volatile auto cvuptrc = std::make_unique<const int>(13);
 
   auto b_ptr = rcpputils::is_pointer<decltype(ptr)>::value;
+  auto b_ptr_ptr = rcpputils::is_pointer<decltype(ptr_ptr)>::value;
+  auto b_ptr2 = rcpputils::is_pointer<decltype(*ptr_ptr)>::value;
   auto b_cptrc = rcpputils::is_pointer<decltype(cptrc)>::value;
   auto b_sptr = rcpputils::is_pointer<decltype(sptr)>::value;
   auto b_csptr = rcpputils::is_pointer<decltype(csptr)>::value;
@@ -43,6 +46,8 @@ TEST(TestPointerTraits, is_pointer) {
   auto b_cvuptrc = rcpputils::is_pointer<decltype(cvuptrc)>::value;
 
   EXPECT_TRUE(b_ptr);
+  EXPECT_TRUE(b_ptr_ptr);
+  EXPECT_TRUE(b_ptr2);
   EXPECT_TRUE(b_cptrc);
   EXPECT_TRUE(b_sptr);
   EXPECT_TRUE(b_csptr);


### PR DESCRIPTION
as per offline discussion, `decltype` preserves a reference when dereferencing a double pointer. See https://stackoverflow.com/a/26697503/4583130 

Signed-off-by: Karsten Knese <karsten@openrobotics.org>