### PR TITLE
Make assert functions accept an optional string.

### DIFF
--- a/include/rcpputils/asserts.hpp
+++ b/include/rcpputils/asserts.hpp
@@ -60,7 +60,7 @@ public:
  * \param msg
  * \throw std::invalid_argument if the condition is not met.
  */
-inline void require_true(bool condition, const std::string & msg = "Invalid argument passed!")
+inline void require_true(bool condition, const std::string & msg = "invalid argument passed")
 {
   if (!condition) {
     throw std::invalid_argument{msg};
@@ -74,7 +74,7 @@ inline void require_true(bool condition, const std::string & msg = "Invalid argu
  * \param msg
  * \throw rcpputils::IllegalStateException if the condition is not met.
  */
-inline void check_true(bool condition, const std::string & msg = "Check reported invalid state!")
+inline void check_true(bool condition, const std::string & msg = "check reported invalid state")
 {
   if (!condition) {
     throw rcpputils::IllegalStateException{msg.c_str()};
@@ -89,7 +89,7 @@ inline void check_true(bool condition, const std::string & msg = "Check reported
  * \param msg
  * \throw rcpputils::AssertionException if the macro NDEBUG is not set and the condition is not met.
  */
-inline void assert_true(bool condition, const std::string & msg = "Assertion failed!")
+inline void assert_true(bool condition, const std::string & msg = "assertion failed")
 {
 // Same macro definition used by cassert
 #ifndef NDEBUG

--- a/include/rcpputils/asserts.hpp
+++ b/include/rcpputils/asserts.hpp
@@ -63,7 +63,7 @@ public:
 inline void require_true(bool condition, const std::string & msg = "Invalid argument passed!")
 {
   if (!condition) {
-    throw std::invalid_argument{msg.c_str()};
+    throw std::invalid_argument{msg};
   }
 }
 

--- a/include/rcpputils/asserts.hpp
+++ b/include/rcpputils/asserts.hpp
@@ -57,12 +57,13 @@ public:
  * Checks that an argument condition passes.
  *
  * \param condition
+ * \param msg
  * \throw std::invalid_argument if the condition is not met.
  */
-inline void require_true(bool condition)
+inline void require_true(bool condition, const std::string & msg = "Invalid argument passed!")
 {
   if (!condition) {
-    throw std::invalid_argument{"Invalid argument passed!"};
+    throw std::invalid_argument{msg.c_str()};
   }
 }
 
@@ -70,12 +71,13 @@ inline void require_true(bool condition)
  * Checks that a state condition passes.
  *
  * \param condition
+ * \param msg
  * \throw rcpputils::IllegalStateException if the condition is not met.
  */
-inline void check_true(bool condition)
+inline void check_true(bool condition, const std::string & msg = "Check reported invalid state!")
 {
   if (!condition) {
-    throw rcpputils::IllegalStateException{"Check reported invalid state!"};
+    throw rcpputils::IllegalStateException{msg.c_str()};
   }
 }
 
@@ -84,17 +86,19 @@ inline void check_true(bool condition)
  *
  * This function behaves similar to assert, except that it throws instead of invoking abort().
  * \param condition
+ * \param msg
  * \throw rcpputils::AssertionException if the macro NDEBUG is not set and the condition is not met.
  */
-inline void assert_true(bool condition)
+inline void assert_true(bool condition, const std::string & msg = "Assertion failed!")
 {
 // Same macro definition used by cassert
 #ifndef NDEBUG
   if (!condition) {
-    throw rcpputils::AssertionException{"Assertion failed!"};
+    throw rcpputils::AssertionException{msg.c_str()};
   }
 #else
   (void) condition;
+  (void) msg;
 #endif
 }
 }  // namespace rcpputils

--- a/test/test_asserts.cpp
+++ b/test/test_asserts.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <stdexcept>
+#include <string>
 
 #include "gtest/gtest.h"
 
@@ -20,6 +21,23 @@
 
 TEST(test_asserts, require_throws_if_condition_is_false) {
   EXPECT_THROW(rcpputils::require_true(false), std::invalid_argument);
+}
+
+TEST(test_asserts, require_throws_with_message_if_condition_is_false) {
+  constexpr const char expected_message[] = "Error Message";
+  bool exception_was_caught = false;
+
+  try {
+    rcpputils::require_true(false, expected_message);
+  } catch (const std::invalid_argument & ex) {
+    const std::string actual{ex.what()};
+    const std::string expected{expected_message};
+
+    EXPECT_EQ(actual, expected);
+    exception_was_caught = true;
+  }
+
+  EXPECT_TRUE(exception_was_caught);
 }
 
 TEST(test_asserts, require_does_not_throw_if_condition_is_true) {
@@ -30,13 +48,47 @@ TEST(test_asserts, check_throws_if_condition_is_false) {
   EXPECT_THROW(rcpputils::check_true(false), rcpputils::IllegalStateException);
 }
 
+TEST(test_asserts, check_throws_with_message_if_condition_is_false) {
+  constexpr const char expected_message[] = "Error Message";
+  bool exception_was_caught = false;
+
+  try {
+    rcpputils::check_true(false, expected_message);
+  } catch (const rcpputils::IllegalStateException & ex) {
+    const std::string actual{ex.what()};
+    const std::string expected{expected_message};
+
+    EXPECT_EQ(actual, expected);
+    exception_was_caught = true;
+  }
+
+  EXPECT_TRUE(exception_was_caught);
+}
+
 TEST(test_asserts, check_does_not_throw_if_condition_is_true) {
   EXPECT_NO_THROW(rcpputils::check_true(true));
 }
 
 #ifndef NDEBUG
-TEST(test_asserts, ros_assert_throws_if_condition_is_false_and_ndebug_not_set) {
+TEST(test_asserts, assert_true_throws_if_condition_is_false_and_ndebug_not_set) {
   EXPECT_THROW(rcpputils::assert_true(false), rcpputils::AssertionException);
+}
+
+TEST(test_asserts, assert_true_throws_with_message_if_condition_is_false_and_ndebug_not_set) {
+  constexpr const char expected_message[] = "Error Message";
+  bool exception_was_caught = false;
+
+  try {
+    rcpputils::assert_true(false, expected_message);
+  } catch (const rcpputils::AssertionException & ex) {
+    const std::string actual{ex.what()};
+    const std::string expected{expected_message};
+
+    EXPECT_EQ(actual, expected);
+    exception_was_caught = true;
+  }
+
+  EXPECT_TRUE(exception_was_caught);
 }
 
 TEST(test_asserts, ros_assert_does_not_throw_if_condition_is_true_and_ndebug_not_set)


### PR DESCRIPTION
### Changes
* Add default msg parameter to `rcpputils::require_true`
* Add default msg parameter to `rcpputils::check_true`
* Add default msg parameter to `rcpputils::assert_true`

Signed-off-by: Zachary Michaels <zmichaels11@gmail.com>