### PR TITLE
Added unload_library method to shared_library

### DIFF
--- a/include/rcpputils/shared_library.hpp
+++ b/include/rcpputils/shared_library.hpp
@@ -84,8 +84,6 @@ public:
 
 private:
   rcutils_shared_library_t lib;
-  /// variable to know if the library is loaded
-  bool is_loaded;
 };
 
 /// Get the platform specific library name

--- a/include/rcpputils/shared_library.hpp
+++ b/include/rcpputils/shared_library.hpp
@@ -84,6 +84,8 @@ public:
 
 private:
   rcutils_shared_library_t lib;
+  /// variable to know if the library is loaded
+  bool is_loaded;
 };
 
 /// Get the platform specific library name

--- a/include/rcpputils/shared_library.hpp
+++ b/include/rcpputils/shared_library.hpp
@@ -45,6 +45,14 @@ public:
   RCPPUTILS_PUBLIC
   virtual ~SharedLibrary();
 
+  /// Unload library
+  /**
+  * \throws std::runtime_error if the library is not unloaded properly
+   */
+  RCPPUTILS_PUBLIC
+  void
+  unload_library();
+
   /// Return true if the shared library contains a specific symbol name otherwise returns false.
   /**
    * \param[in] symbol_name name of the symbol inside the shared library

--- a/src/shared_library.cpp
+++ b/src/shared_library.cpp
@@ -41,20 +41,11 @@ SharedLibrary::SharedLibrary(const std::string & library_path)
 
 SharedLibrary::~SharedLibrary()
 {
-  if (lib.lib_pointer != NULL) {
+  if (rcutils_is_shared_library_loaded(&lib)) {
     rcutils_ret_t ret = rcutils_unload_shared_library(&lib);
     if (ret != RCUTILS_RET_OK) {
       std::cerr << rcutils_get_error_string().str << std::endl;
       rcutils_reset_error();
-    }
-  } else {
-    if (lib.library_path != NULL) {
-      if (rcutils_allocator_is_valid(&lib.allocator)) {
-        lib.allocator.deallocate(lib.library_path, lib.allocator.state);
-        lib.allocator = rcutils_get_zero_initialized_allocator();
-      } else {
-        std::cerr << "ShareLibrary not able to deallocate memory on constructor" << std::endl;
-      }
     }
   }
 }

--- a/src/shared_library.cpp
+++ b/src/shared_library.cpp
@@ -23,6 +23,7 @@ namespace rcpputils
 {
 SharedLibrary::SharedLibrary(const std::string & library_path)
 {
+  is_loaded = false;
   lib = rcutils_get_zero_initialized_shared_library();
   rcutils_ret_t ret = rcutils_load_shared_library(
     &lib,
@@ -37,19 +38,23 @@ SharedLibrary::SharedLibrary(const std::string & library_path)
       throw std::runtime_error{rcutils_error_str};
     }
   }
+  is_loaded = true;
 }
 
 SharedLibrary::~SharedLibrary()
 {
-  rcutils_ret_t ret = rcutils_unload_shared_library(&lib);
-  if (ret != RCUTILS_RET_OK) {
-    std::cerr << rcutils_get_error_string().str << std::endl;
-    rcutils_reset_error();
+  if (is_loaded) {
+    rcutils_ret_t ret = rcutils_unload_shared_library(&lib);
+    if (ret != RCUTILS_RET_OK) {
+      std::cerr << rcutils_get_error_string().str << std::endl;
+      rcutils_reset_error();
+    }
   }
 }
 
 void SharedLibrary::unload_library()
 {
+  is_loaded = false;
   rcutils_ret_t ret = rcutils_unload_shared_library(&lib);
   if (ret != RCUTILS_RET_OK) {
     std::string rcutils_error_str(rcutils_get_error_string().str);

--- a/src/shared_library.cpp
+++ b/src/shared_library.cpp
@@ -48,6 +48,16 @@ SharedLibrary::~SharedLibrary()
   }
 }
 
+void SharedLibrary::unload_library()
+{
+  rcutils_ret_t ret = rcutils_unload_shared_library(&lib);
+  if (ret != RCUTILS_RET_OK) {
+    std::string rcutils_error_str(rcutils_get_error_string().str);
+    rcutils_reset_error();
+    throw std::runtime_error{rcutils_error_str};
+  }
+}
+
 void * SharedLibrary::get_symbol(const std::string & symbol_name)
 {
   void * lib_symbol = rcutils_get_symbol(&lib, symbol_name.c_str());

--- a/test/test_shared_library.cpp
+++ b/test/test_shared_library.cpp
@@ -54,4 +54,13 @@ TEST(test_shared_library, failed_test) {
   } catch (...) {
     FAIL();
   }
+
+  try {
+    auto library = std::make_shared<rcpputils::SharedLibrary>(library_path);
+
+    EXPECT_NO_THROW(library->unload_library());
+    EXPECT_THROW(library->unload_library(), std::runtime_error);
+  } catch (...) {
+    FAIL();
+  }
 }


### PR DESCRIPTION
As discussed in the PR https://github.com/ros/class_loader/pull/139#pullrequestreview-387397419 I will include a unload method to the sharedLibrary abstraction

Signed-off-by: ahcorde <ahcorde@gmail.com>