### PR TITLE
Removed duplicated split function

### DIFF
--- a/src/find_library.cpp
+++ b/src/find_library.cpp
@@ -21,9 +21,12 @@
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include "rcutils/filesystem.h"
 #include "rcutils/get_env.h"
+
+#include "rcpputils/split.hpp"
 
 namespace rcpputils
 {
@@ -58,23 +61,12 @@ std::string get_env_var(const char * env_var)
   return value ? value : "";
 }
 
-std::list<std::string> split(const std::string & value, const char delimiter)
-{
-  std::list<std::string> list;
-  std::istringstream ss(value);
-  std::string s;
-  while (std::getline(ss, s, delimiter)) {
-    list.push_back(s);
-  }
-  return list;
-}
-
 }  // namespace
 
 std::string find_library_path(const std::string & library_name)
 {
   std::string search_path = get_env_var(kPathVar);
-  std::list<std::string> search_paths = split(search_path, kPathSeparator);
+  std::vector<std::string> search_paths = rcpputils::split(search_path, kPathSeparator);
 
   std::string filename = kSolibPrefix;
   filename += library_name + kSolibExtension;

--- a/src/find_library.cpp
+++ b/src/find_library.cpp
@@ -51,8 +51,6 @@ static constexpr char kSolibPrefix[] = "lib";
 static constexpr char kSolibExtension[] = ".so";
 #endif
 
-}
-
 }  // namespace
 
 std::string find_library_path(const std::string & library_name)

--- a/src/find_library.cpp
+++ b/src/find_library.cpp
@@ -17,7 +17,6 @@
 #include <cassert>
 #include <cstddef>
 
-#include <list>
 #include <fstream>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
Removed a duplicated version of the split function. Using the one defined in `split.hpp`.

https://github.com/ros2/rcpputils/blob/90adaa69fdd92dacb741e81e6d52df6cbedba05b/include/rcpputils/split.hpp#L89-L95

Signed-off-by: ahcorde <ahcorde@gmail.com>