### PR TITLE
Exposed get_env_var

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,13 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_join test/test_join.cpp)
 
+  ament_add_gtest(test_get_env test/test_get_env.cpp
+    ENV
+      EMPTY_TEST=
+      NORMAL_TEST=foo
+  )
+  ament_target_dependencies(test_get_env rcutils)
+
   ament_add_gtest(test_split test/test_split.cpp)
 
   ament_add_gtest(test_filesystem_helper test/test_filesystem_helper.cpp)

--- a/include/rcpputils/get_env.hpp
+++ b/include/rcpputils/get_env.hpp
@@ -48,7 +48,6 @@ namespace rcpputils
  * \return The value of the environment variable if it exists, or "".
  * \throws std::runtime_error on error
  */
-RCPPUTILS_PUBLIC
 std::string get_env_var(const char * env_var)
 {
   const char * value{};

--- a/include/rcpputils/get_env.hpp
+++ b/include/rcpputils/get_env.hpp
@@ -33,7 +33,11 @@
 #ifndef RCPPUTILS__GET_ENV_HPP_
 #define RCPPUTILS__GET_ENV_HPP_
 
+#include "rcutils/get_env.h"
+
 #include <string>
+
+#include "rcpputils/visibility_control.hpp"
 
 namespace rcpputils
 {

--- a/include/rcpputils/get_env.hpp
+++ b/include/rcpputils/get_env.hpp
@@ -1,0 +1,60 @@
+// Copyright (c) 2020, Open Source Robotics Foundation, Inc.
+// All rights reserved.
+//
+// Software License Agreement (BSD License 2.0)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//  * Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef RCPPUTILS__GET_ENV_HPP_
+#define RCPPUTILS__GET_ENV_HPP_
+
+#include <string>
+
+namespace rcpputils
+{
+
+/// Retrieve the value of the given environment variable if it exists, or "".
+/*
+ * \param[in] env_var the name of the environment variable
+ * \return The value of the environment variable if it exists, or "".
+ * \throws std::runtime_error on error
+ */
+RCPPUTILS_PUBLIC
+std::string get_env_var(const char * env_var)
+{
+  const char * value{};
+  const char * err = rcutils_get_env(env_var, &value);
+  if (err) {
+    throw std::runtime_error(err);
+  }
+  return value ? value : "";
+}
+
+}  // namespace rcpputils
+
+#endif  // RCPPUTILS__GET_ENV_HPP_

--- a/src/find_library.cpp
+++ b/src/find_library.cpp
@@ -25,6 +25,8 @@
 #include "rcutils/filesystem.h"
 #include "rcutils/get_env.h"
 
+#include "rcpputils/get_env.hpp"
+
 namespace rcpputils
 {
 
@@ -47,16 +49,6 @@ static constexpr char kPathSeparator = ':';
 static constexpr char kSolibPrefix[] = "lib";
 static constexpr char kSolibExtension[] = ".so";
 #endif
-
-std::string get_env_var(const char * env_var)
-{
-  const char * value{};
-  const char * err = rcutils_get_env(env_var, &value);
-  if (err) {
-    throw std::runtime_error(err);
-  }
-  return value ? value : "";
-}
 
 std::list<std::string> split(const std::string & value, const char delimiter)
 {

--- a/test/test_get_env.cpp
+++ b/test/test_get_env.cpp
@@ -1,0 +1,39 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <rcpputils/get_env.hpp>
+
+#include <string>
+
+/* Tests get_env_var.
+ *
+ * Expected environment variables must be set by the calling code:
+ *
+ *   - EMPTY_TEST=
+ *   - NORMAL_TEST=foo
+ *
+ * These are set in the call to `ament_add_gtest()` in the `CMakeLists.txt`.
+ */
+
+TEST(TestGetEnv, test_get_env) {
+  std::string env;
+  env = rcpputils::get_env_var("NORMAL_TEST");
+  EXPECT_STREQ("foo", env.c_str());
+  env = rcpputils::get_env_var("SHOULD_NOT_EXIST_TEST");
+  EXPECT_STREQ("", env.c_str());
+  env = rcpputils::get_env_var("EMPTY_TEST");
+  EXPECT_STREQ("", env.c_str());
+}


### PR DESCRIPTION
get_env_var is redefined in [rmw_implementation](https://github.com/ros2/rmw_implementation/blob/master/rmw_implementation/src/functions.cpp#L41). I exposed this function is rcpputils to avoid duplications of code.

Signed-off-by: ahcorde <ahcorde@gmail.com>