### PR TITLE
remove pointer for smart pointer

### DIFF
--- a/include/rcpputils/pointer_traits.hpp
+++ b/include/rcpputils/pointer_traits.hpp
@@ -44,6 +44,21 @@ template<class T>
 struct is_smart_pointer : is_smart_pointer_helper<typename std::remove_cv<T>::type>
 {};
 
+template<
+  class T,
+  bool is_smart_pointer
+>
+struct remove_pointer
+{
+  using type = typename std::remove_pointer<T>::type;
+};
+
+template<class T>
+struct remove_pointer<T, true>
+{
+  using type = typename std::remove_pointer<
+    decltype(std::declval<typename std::remove_volatile<T>::type>().get())>::type;
+};
 }  // namespace details
 
 /// Type traits for validating if T is of type pointer or smart pointer
@@ -75,6 +90,21 @@ struct is_pointer
   /// Indicates whether this object is a pointer or smart pointer.
   static constexpr bool value = std::is_pointer<typename std::remove_reference<T>::type>::value ||
     details::is_smart_pointer<typename std::remove_reference<T>::type>::value;
+};
+
+/// Type traits for deducing the data type of T from a pointer or smart pointer.
+/**
+ * In comparison to the existing type trait for pointer in the stdlib `std::remove_pointer<T>`
+ * https://en.cppreference.com/w/cpp/types/remove_pointer this trait is enhancing it for
+ * checking of smart pointer types as well.
+ * The valid pointer types are T*, std::shared_pointer<T> and std::unique_ptr<T>
+ *
+ */
+template<class T>
+struct remove_pointer
+{
+  using type = typename details::remove_pointer<
+    typename std::remove_reference<T>::type, details::is_smart_pointer<T>::value>::type;
 };
 
 }  // namespace rcpputils

--- a/test/test_pointer_traits.cpp
+++ b/test/test_pointer_traits.cpp
@@ -37,6 +37,7 @@ TEST(TestPointerTraits, is_pointer) {
   auto b_ptr2 = rcpputils::is_pointer<decltype(*ptr_ptr)>::value;
   auto b_cptrc = rcpputils::is_pointer<decltype(cptrc)>::value;
   auto b_sptr = rcpputils::is_pointer<decltype(sptr)>::value;
+  auto b_sptr_ref = rcpputils::is_pointer<decltype(sptr) &>::value;
   auto b_csptr = rcpputils::is_pointer<decltype(csptr)>::value;
   auto b_cvsptr = rcpputils::is_pointer<decltype(cvsptr)>::value;
   auto b_cvsptrc = rcpputils::is_pointer<decltype(cvsptrc)>::value;
@@ -50,6 +51,7 @@ TEST(TestPointerTraits, is_pointer) {
   EXPECT_TRUE(b_ptr2);
   EXPECT_TRUE(b_cptrc);
   EXPECT_TRUE(b_sptr);
+  EXPECT_TRUE(b_sptr_ref);
   EXPECT_TRUE(b_csptr);
   EXPECT_TRUE(b_cvsptr);
   EXPECT_TRUE(b_cvsptrc);
@@ -81,4 +83,47 @@ TEST(TestPointerTraits, is_no_pointer) {
   EXPECT_FALSE(b_i);
   EXPECT_FALSE(b_s);
   EXPECT_FALSE(b_pod);
+}
+
+TEST(TestPointerTraits, remove_pointer) {
+  auto non_ptr = 13;
+  auto ptr = new int(13);
+  auto ptr_ptr = &ptr;
+  const auto * const cptrc = new int(13);
+  auto sptr = std::make_shared<int>(13);
+  const auto csptr = std::make_shared<int>(13);
+  const volatile auto cvsptr = std::make_shared<int>(13);
+  const volatile auto cvsptrc = std::make_shared<int const>(13);
+  auto uptr = std::make_unique<int>(13);
+  const auto cuptr = std::make_unique<int>(13);
+  const volatile auto cvuptr = std::make_unique<int>(13);
+  const volatile auto cvuptrc = std::make_unique<const int>(13);
+
+  auto b_non_ptr = std::is_same<rcpputils::remove_pointer<decltype(non_ptr)>::type, int>::value;
+  auto b_ptr = std::is_same<rcpputils::remove_pointer<decltype(ptr)>::type, int>::value;
+  auto b_ptr_ptr = std::is_same<rcpputils::remove_pointer<decltype(ptr_ptr)>::type, int>::value;
+  auto b_cptrc = std::is_same<rcpputils::remove_pointer<decltype(cptrc)>::type, const int>::value;
+  auto b_sptr = std::is_same<rcpputils::remove_pointer<decltype(sptr)>::type, int>::value;
+  auto b_csptr = std::is_same<rcpputils::remove_pointer<decltype(csptr)>::type, int>::value;
+  auto b_cvsptr = std::is_same<rcpputils::remove_pointer<decltype(cvsptr)>::type, int>::value;
+  auto b_cvsptrc =
+    std::is_same<rcpputils::remove_pointer<decltype(cvsptrc)>::type, const int>::value;
+  auto b_uptr = std::is_same<rcpputils::remove_pointer<decltype(uptr)>::type, int>::value;
+  auto b_cuptr = std::is_same<rcpputils::remove_pointer<decltype(cuptr)>::type, int>::value;
+  auto b_cvuptr = std::is_same<rcpputils::remove_pointer<decltype(cvuptr)>::type, int>::value;
+  auto b_cvuptrc =
+    std::is_same<rcpputils::remove_pointer<decltype(cvuptrc)>::type, const int>::value;
+
+  EXPECT_TRUE(b_non_ptr);
+  EXPECT_TRUE(b_ptr);
+  EXPECT_FALSE(b_ptr_ptr);
+  EXPECT_TRUE(b_cptrc);
+  EXPECT_TRUE(b_sptr);
+  EXPECT_TRUE(b_csptr);
+  EXPECT_TRUE(b_cvsptr);
+  EXPECT_TRUE(b_cvsptrc);
+  EXPECT_TRUE(b_uptr);
+  EXPECT_TRUE(b_cuptr);
+  EXPECT_TRUE(b_cvuptr);
+  EXPECT_TRUE(b_cvuptrc);
 }


### PR DESCRIPTION
same as `std::remove_pointer<T>` but also accounting for smart pointers.

used by https://github.com/ros2/rclcpp/pull/1069