### PR TITLE
Fix Action CI by using released upload-artifact instead of master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: ros-tooling/action-ros-ci@0.0.13
       with:
         package-name: rcpputils
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@v2
       with:
         name: colcon-logs
         path: ros_ws/log

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: ros-tooling/action-ros-ci@0.0.13
       with:
         package-name: rcpputils
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v1
       with:
         name: colcon-logs
         path: ros_ws/log


### PR DESCRIPTION
Master is failing for some reason for ~24h now - see e.g. https://github.com/ros2/rcpputils/actions/runs/91463594

Switch over to the official release of the action, which should be stable.

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>