### PR TITLE
Add current_path to filesystem_helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,11 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_split test/test_split.cpp)
 
-  ament_add_gtest(test_filesystem_helper test/test_filesystem_helper.cpp)
+  ament_add_gtest(test_filesystem_helper test/test_filesystem_helper.cpp
+    ENV
+      EXPECTED_WORKING_DIRECTORY=$<SHELL_PATH:${CMAKE_CURRENT_BINARY_DIR}>
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  ament_target_dependencies(test_filesystem_helper rcutils)
 
   ament_add_gtest(test_find_and_replace test/test_find_and_replace.cpp)
 

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -44,6 +44,7 @@
 #ifndef RCPPUTILS__FILESYSTEM_HELPER_HPP_
 #define RCPPUTILS__FILESYSTEM_HELPER_HPP_
 
+#include <limits.h>
 #include <sys/stat.h>
 
 #include <algorithm>
@@ -421,24 +422,22 @@ inline path temp_directory_path()
  */
 inline path current_path()
 {
-  char * cwd;
 #ifdef _WIN32
 #ifdef UNICODE
 #error "rcpputils::fs does not support Unicode paths"
 #endif
-  cwd = _getcwd(NULL, 0);
+  char cwd[MAX_PATH];
+  if (nullptr == _getcwd(cwd, MAX_PATH)) {
 #else
-  cwd = getcwd(NULL, 0);
+  char cwd[PATH_MAX];
+  if (nullptr == getcwd(cwd, PATH_MAX)) {
 #endif
-  if (nullptr == cwd) {
     std::error_code ec{errno, std::system_category()};
     errno = 0;
     throw std::system_error{ec, "cannot get current working directory"};
   }
 
-  std::string ret(cwd);
-  free(cwd);
-  return path(ret);
+  return path(cwd);
 }
 
 /**

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -413,6 +413,35 @@ inline path temp_directory_path()
 }
 
 /**
+ * \brief Return current working directory.
+ *
+ * \return The current working directory.
+ *
+ * \throws std::system_error
+ */
+inline path current_path()
+{
+  char * cwd;
+#ifdef _WIN32
+#ifdef UNICODE
+#error "rcpputils::fs does not support Unicode paths"
+#endif
+  cwd = _getcwd(NULL, 0);
+#else
+  cwd = getcwd(NULL, 0);
+#endif
+  if (nullptr == cwd) {
+    std::error_code ec{errno, std::system_category()};
+    errno = 0;
+    throw std::system_error{ec, "cannot get current working directory"};
+  }
+
+  std::string ret(cwd);
+  free(cwd);
+  return path(ret);
+}
+
+/**
  * \brief Create a directory with the given path p.
  *
  * This builds directories recursively and will skip directories if they are already created.

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "rcpputils/filesystem_helper.hpp"
+#include "rcpputils/get_env.hpp"
 
 #ifdef _WIN32
 static constexpr const bool is_win32 = true;
@@ -232,6 +233,7 @@ TEST(TestFilesystemHelper, remove_extension_no_extension)
 
 TEST(TestFilesystemHelper, get_cwd)
 {
+  std::string expected_dir = rcpputils::get_env_var("EXPECTED_WORKING_DIRECTORY");
   auto p = rcpputils::fs::current_path();
-  EXPECT_FALSE(p.empty());
+  EXPECT_EQ(expected_dir, p.string());
 }

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -229,3 +229,9 @@ TEST(TestFilesystemHelper, remove_extension_no_extension)
   p = rcpputils::fs::remove_extension(p);
   EXPECT_EQ("foo", p.string());
 }
+
+TEST(TestFilesystemHelper, get_cwd)
+{
+  auto p = rcpputils::fs::current_path();
+  EXPECT_FALSE(p.empty());
+}


### PR DESCRIPTION
Modeled after the C++ 17 function: https://en.cppreference.com/w/cpp/filesystem/current_path

I decided not to use the `rcutils_get_cwd` so that error information could be reliably propagated and so that the buffer could be dynamically allocated.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11020)](http://ci.ros2.org/job/ci_linux/11020/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6352)](http://ci.ros2.org/job/ci_linux-aarch64/6352/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8977)](http://ci.ros2.org/job/ci_osx/8977/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10947)](http://ci.ros2.org/job/ci_windows/10947/)