### PR TITLE
Remove mention of random file from temporary_directory_path doc

### DIFF
--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -388,7 +388,7 @@ inline bool exists(const path & path_to_check)
 /**
  * \brief Get a path to a location in the temporary directory, if it's available.
  *
- * \return A path to a randomly generated file location in the temporary directory.
+ * \return A path to a directory for storing temporary files and directories.
  */
 inline path temp_directory_path()
 {


### PR DESCRIPTION
The documented return value for this function seems to reference a different temp function - one that returns a random temp filename. The implementation is returning the path to a temp directory as instructed through environment variables and not a path to a file.

The implementation aligns with the C++ 17 function, so I'm inclined to believe that the documentation is wrong: https://en.cppreference.com/w/cpp/filesystem/temp_directory_path