### PR TITLE
Update quality declaration for version stability.

### DIFF
--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -14,7 +14,8 @@ Below are the rationales, notes, and caveats for this claim, organized by each r
 
 ### Version Stability [1.ii]
 
-`rcpputils` is not yet at a stable version, i.e. `>= 1.0.0`.
+`rcpputils` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
 
 ### Public API Declaration [1.iii]
 


### PR DESCRIPTION
1.0 for this package was bumped in https://github.com/ros2/rcpputils/commit/547498373d8cc9f9413c2f9a4a81db91b410787e so this updates the quality declaration.

It looks to me like this might make the package level 2 or level 3 but for the rcutils dependency. I'd appreciate a comment on that front from someone whose got more familiarity with what's part of each quality level.