### PR TITLE
Handle empty paths in is_absolute

### DIFF
--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -219,7 +219,8 @@ public:
   */
   bool is_absolute() const
   {
-    return path_.compare(0, 1, "/") == 0 || path_.compare(1, 2, ":\\") == 0;
+    return path_.size() > 0 &&
+           (path_.compare(0, 1, "/") == 0 || path_.compare(1, 2, ":\\") == 0);
   }
 
   /**

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -120,6 +120,18 @@ TEST(TestFilesystemHelper, is_absolute)
       auto p = path("foo/bar/baz");
       EXPECT_FALSE(p.is_absolute());
     }
+    {
+      auto p = path("C:");
+      EXPECT_FALSE(p.is_absolute());
+    }
+    {
+      auto p = path("C");
+      EXPECT_FALSE(p.is_absolute());
+    }
+    {
+      auto p = path("");
+      EXPECT_FALSE(p.is_absolute());
+    }
   } else {
     {
       auto p = path("/foo/bar/baz");
@@ -127,6 +139,14 @@ TEST(TestFilesystemHelper, is_absolute)
     }
     {
       auto p = path("foo/bar/baz");
+      EXPECT_FALSE(p.is_absolute());
+    }
+    {
+      auto p = path("f");
+      EXPECT_FALSE(p.is_absolute());
+    }
+    {
+      auto p = path("");
       EXPECT_FALSE(p.is_absolute());
     }
   }


### PR DESCRIPTION
Currently seeing this:
```
unknown file: Failure
C++ exception with description "basic_string::compare: __pos (which is 1) > this->size() (which is 0)" thrown in the test body.
```