### PR TITLE
Align path combine behavior with C++17

### DIFF
--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -326,10 +326,15 @@ public:
   */
   path & operator/=(const path & other)
   {
-    this->path_ += kPreferredSeparator + other.string();
-    this->path_as_vector_.insert(
-      std::end(this->path_as_vector_),
-      std::begin(other.path_as_vector_), std::end(other.path_as_vector_));
+    if (other.is_absolute()) {
+      this->path_ = other.path_;
+      this->path_as_vector_ = other.path_as_vector_;
+    } else {
+      this->path_ += kPreferredSeparator + other.string();
+      this->path_as_vector_.insert(
+        std::end(this->path_as_vector_),
+        std::begin(other.path_as_vector_), std::end(other.path_as_vector_));
+    }
     return *this;
   }
 

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -49,12 +49,21 @@ std::string build_directory_path()
 
 TEST(TestFilesystemHelper, join_path)
 {
-  auto p = path("foo") / path("bar");
+  {
+    auto p = path("foo") / path("bar");
+    if (is_win32) {
+      EXPECT_EQ("foo\\bar", p.string());
+    } else {
+      EXPECT_EQ("foo/bar", p.string());
+    }
+  }
 
   if (is_win32) {
-    EXPECT_EQ("foo\\bar", p.string());
+    auto p = path("foo") / path("C:\\bar");
+    EXPECT_EQ("C:\\bar", p.string());
   } else {
-    EXPECT_EQ("foo/bar", p.string());
+    auto p = path("foo") / path("/bar");
+    EXPECT_EQ("/bar", p.string());
   }
 }
 


### PR DESCRIPTION
Combining any path with an absolute path yields only the absolute path in the C++17 implementation.

The current behavior here is to smush them together anyway.

Requires #67