### PR TITLE
Add get_executable_name() function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,9 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_pointer_traits test/test_pointer_traits.cpp)
 
+  ament_add_gtest(test_process test/test_process.cpp)
+  ament_target_dependencies(test_process rcutils)
+
   set(append_library_dirs "$<TARGET_FILE_DIR:${PROJECT_NAME}>")
 
   ament_add_gtest(test_shared_library test/test_shared_library.cpp

--- a/include/rcpputils/process.hpp
+++ b/include/rcpputils/process.hpp
@@ -1,0 +1,50 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCPPUTILS__PROCESS_HPP_
+#define RCPPUTILS__PROCESS_HPP_
+
+#include <rcutils/process.h>
+
+#include <string>
+
+namespace rcpputils
+{
+
+/// Retrieve the current executable name.
+/**
+ * This function portably retrieves the current program name and returns
+ * a copy of it.
+ * It is up to the caller to free the memory.
+ *
+ * This function is thread-safe.
+ *
+ * \return The program name.
+ * \throws std::runtime_error on error
+ */
+std::string get_executable_name()
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  char * executable_name = rcutils_get_executable_name(allocator);
+  if (nullptr == executable_name) {
+    throw std::runtime_error("Failed to get executable name");
+  }
+  std::string ret(executable_name);
+  allocator.deallocate(executable_name, allocator.state);
+  return ret;
+}
+
+}  // namespace rcpputils
+
+#endif  // RCPPUTILS__PROCESS_HPP_

--- a/include/rcpputils/process.hpp
+++ b/include/rcpputils/process.hpp
@@ -26,7 +26,6 @@ namespace rcpputils
 /**
  * This function portably retrieves the current program name and returns
  * a copy of it.
- * It is up to the caller to free the memory.
  *
  * This function is thread-safe.
  *

--- a/test/test_process.cpp
+++ b/test/test_process.cpp
@@ -19,5 +19,5 @@
 #include "rcpputils/process.hpp"
 
 TEST(TestProcess, test_get_executable_name) {
-  EXPECT_STREQ("test_process", rcpputils::get_executable_name().c_str());
+  EXPECT_EQ("test_process", rcpputils::get_executable_name());
 }

--- a/test/test_process.cpp
+++ b/test/test_process.cpp
@@ -1,0 +1,23 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "rcpputils/process.hpp"
+
+TEST(TestProcess, test_get_executable_name) {
+  EXPECT_STREQ("test_process", rcpputils::get_executable_name().c_str());
+}


### PR DESCRIPTION
This function wraps `rcutils_get_executable_name`. It takes care of the allocator and throws an exception when an error occurs.

The rcutils_get_executable_name implementation doesn't set any error information when it fails, and from reading through the implementation and the documentation for the system functions it calls, an error should be extremely unlikely. A generic failure message is the best I can do.

Inspired by https://github.com/ros2/rcl_logging/pull/40#discussion_r434196444

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11024)](http://ci.ros2.org/job/ci_linux/11024/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6356)](http://ci.ros2.org/job/ci_linux-aarch64/6356/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8981)](http://ci.ros2.org/job/ci_osx/8981/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10951)](http://ci.ros2.org/job/ci_windows/10951/)