### PR TITLE
Address memory leak in remove pointer test

### DIFF
--- a/test/test_pointer_traits.cpp
+++ b/test/test_pointer_traits.cpp
@@ -126,4 +126,7 @@ TEST(TestPointerTraits, remove_pointer) {
   EXPECT_TRUE(b_cuptr);
   EXPECT_TRUE(b_cvuptr);
   EXPECT_TRUE(b_cvuptrc);
+
+  delete ptr;
+  delete cptrc;
 }


### PR DESCRIPTION
The remove_pointer test was not freeing up pointers that were explicitly new'd. 

https://ci.ros2.org/view/nightly/job/nightly_linux_address_sanitizer/432/testReport/(root)/projectroot/test_pointer_traits/

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11063)](http://ci.ros2.org/job/ci_linux/11063/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6379)](http://ci.ros2.org/job/ci_linux-aarch64/6379/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9006)](http://ci.ros2.org/job/ci_osx/9006/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10979)](http://ci.ros2.org/job/ci_windows/10979/)

Signed-off-by: Stephen Brawner <brawner@gmail.com>