### PR TITLE
Fix parent_path() for empty paths and paths of length one

### DIFF
--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -251,6 +251,15 @@ public:
   */
   path parent_path() const
   {
+    // Edge case: if path only consists of one part, then return '.' or '/'
+    //            depending if the path is absolute or not
+    if (1u == path_as_vector_.size()) {
+      if (this->is_absolute()) {
+        return path(std::string(1, kPreferredSeparator));
+      }
+      return path(".");
+    }
+
     path parent;
     for (auto it = this->cbegin(); it != --this->cend(); ++it) {
       if (!parent.empty() || it->empty()) {

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -221,7 +221,8 @@ public:
   bool is_absolute() const
   {
     return path_.size() > 0 &&
-           (path_.compare(0, 1, "/") == 0 || path_.compare(1, 2, ":\\") == 0);
+           (path_.compare(0, 1, std::string(1, kPreferredSeparator)) == 0 ||
+           this->is_absolute_with_drive_letter());
   }
 
   /**
@@ -260,9 +261,19 @@ public:
     //            depending if the path is absolute or not
     if (1u == path_as_vector_.size()) {
       if (this->is_absolute()) {
+        // Windows is tricky, since an absolute path may start with 'C:\\' or '\\'
+        if (this->is_absolute_with_drive_letter()) {
+          return path(path_as_vector_[0] + kPreferredSeparator);
+        }
         return path(std::string(1, kPreferredSeparator));
       }
       return path(".");
+    }
+
+    // Edge case: with a path 'C:\\foo' we want to return 'C:\\' not 'C:'
+    // Don't drop the root directory from an absolute path on Windows starting with a letter drive
+    if (2u == path_as_vector_.size() && this->is_absolute_with_drive_letter()) {
+      return path(path_as_vector_[0] + kPreferredSeparator);
     }
 
     path parent;
@@ -355,6 +366,19 @@ public:
   }
 
 private:
+  /// Returns true if the path is an absolute path with a drive letter on Windows
+  bool is_absolute_with_drive_letter() const
+  {
+#ifdef _WIN32
+    if (path_.empty()) {
+      return false;
+    }
+    return 0 == path_.compare(1, 2, ":\\");
+#else
+    return false;  // only Windows contains absolute paths starting with drive letters
+#endif
+  }
+
   std::string path_;
   std::vector<std::string> path_as_vector_;
 };

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -251,6 +251,11 @@ public:
   */
   path parent_path() const
   {
+    // Edge case: empty path
+    if (this->empty()) {
+      return path("");
+    }
+
     // Edge case: if path only consists of one part, then return '.' or '/'
     //            depending if the path is absolute or not
     if (1u == path_as_vector_.size()) {

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -87,6 +87,10 @@ TEST(TestFilesystemHelper, parent_path)
       EXPECT_EQ(p.parent_path().string(), "/");
     }
   }
+  {
+    auto p = path("");
+    EXPECT_EQ(p.parent_path().string(), "");
+  }
 }
 
 TEST(TestFilesystemHelper, to_native_path)

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -70,9 +70,23 @@ TEST(TestFilesystemHelper, join_path)
 
 TEST(TestFilesystemHelper, parent_path)
 {
-  auto p = path("my") / path("path");
-
-  EXPECT_EQ(p.parent_path().string(), path("my").string());
+  {
+    auto p = path("my") / path("path");
+    EXPECT_EQ(p.parent_path().string(), path("my").string());
+  }
+  {
+    auto p = path("foo");
+    EXPECT_EQ(p.parent_path().string(), ".");
+  }
+  {
+    if (is_win32) {
+      auto p = path("\\foo");
+      EXPECT_EQ(p.parent_path().string(), "\\");
+    } else {
+      auto p = path("/foo");
+      EXPECT_EQ(p.parent_path().string(), "/");
+    }
+  }
 }
 
 TEST(TestFilesystemHelper, to_native_path)

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -80,8 +80,14 @@ TEST(TestFilesystemHelper, parent_path)
   }
   {
     if (is_win32) {
-      auto p = path("C:\\foo");
-      EXPECT_EQ(p.parent_path().string(), "C:");
+      {
+        auto p = path("C:\\foo");
+        EXPECT_EQ(p.parent_path().string(), "C:\\");
+      }
+      {
+        auto p = path("\\foo");
+        EXPECT_EQ(p.parent_path().string(), "\\");
+      }
     } else {
       auto p = path("/foo");
       EXPECT_EQ(p.parent_path().string(), "/");
@@ -89,8 +95,14 @@ TEST(TestFilesystemHelper, parent_path)
   }
   {
     if (is_win32) {
-      auto p = path("C:\\");
-      EXPECT_EQ(p.parent_path().string(), "C:");
+      {
+        auto p = path("C:\\");
+        EXPECT_EQ(p.parent_path().string(), "C:\\");
+      }
+      {
+        auto p = path("\\");
+        EXPECT_EQ(p.parent_path().string(), "\\");
+      }
     } else {
       auto p = path("/");
       EXPECT_EQ(p.parent_path().string(), "/");
@@ -151,6 +163,14 @@ TEST(TestFilesystemHelper, is_absolute)
     }
     {
       auto p = path("C:/foo/bar/baz");
+      EXPECT_TRUE(p.is_absolute());
+    }
+    {
+      auto p = path("\\foo\\bar\\baz");
+      EXPECT_TRUE(p.is_absolute());
+    }
+    {
+      auto p = path("/foo/bar/baz");
       EXPECT_TRUE(p.is_absolute());
     }
     {

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -88,6 +88,15 @@ TEST(TestFilesystemHelper, parent_path)
     }
   }
   {
+    if (is_win32) {
+      auto p = path("C:\\");
+      EXPECT_EQ(p.parent_path().string(), "C:\\");
+    } else {
+      auto p = path("/");
+      EXPECT_EQ(p.parent_path().string(), "/");
+    }
+  }
+  {
     auto p = path("");
     EXPECT_EQ(p.parent_path().string(), "");
   }

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -80,8 +80,8 @@ TEST(TestFilesystemHelper, parent_path)
   }
   {
     if (is_win32) {
-      auto p = path("\\foo");
-      EXPECT_EQ(p.parent_path().string(), "\\");
+      auto p = path("C:\\foo");
+      EXPECT_EQ(p.parent_path().string(), "C:\\");
     } else {
       auto p = path("/foo");
       EXPECT_EQ(p.parent_path().string(), "/");

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -81,7 +81,7 @@ TEST(TestFilesystemHelper, parent_path)
   {
     if (is_win32) {
       auto p = path("C:\\foo");
-      EXPECT_EQ(p.parent_path().string(), "C:\\");
+      EXPECT_EQ(p.parent_path().string(), "C:");
     } else {
       auto p = path("/foo");
       EXPECT_EQ(p.parent_path().string(), "/");
@@ -90,7 +90,7 @@ TEST(TestFilesystemHelper, parent_path)
   {
     if (is_win32) {
       auto p = path("C:\\");
-      EXPECT_EQ(p.parent_path().string(), "C:\\");
+      EXPECT_EQ(p.parent_path().string(), "C:");
     } else {
       auto p = path("/");
       EXPECT_EQ(p.parent_path().string(), "/");

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -187,6 +187,22 @@ TEST(TestFilesystemHelper, is_empty)
   EXPECT_TRUE(p.empty());
 }
 
+TEST(TestFilesystemHelper, exists)
+{
+  {
+    auto p = path("");
+    EXPECT_FALSE(p.exists());
+  }
+  {
+    auto p = path(".");
+    EXPECT_TRUE(p.exists());
+  }
+  {
+    auto p = path("..");
+    EXPECT_TRUE(p.exists());
+  }
+}
+
 /**
  * Test filesystem manipulation API.
  *

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -228,6 +228,15 @@ TEST(TestFilesystemHelper, exists)
     auto p = path("..");
     EXPECT_TRUE(p.exists());
   }
+  {
+    if (is_win32) {
+      auto p = path("\\");
+      EXPECT_TRUE(p.exists());
+    } else {
+      auto p = path("/");
+      EXPECT_TRUE(p.exists());
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
Slightly unrelated, but this PR also adds tests for `exists()` to clarify it's expected behavior (36ebd99).

This fixes an issue discovered downstream: https://github.com/ros2/rosbag2/pull/345/files#r442416506