### PR TITLE
Fast-forward Foxy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,11 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_split test/test_split.cpp)
 
-  ament_add_gtest(test_filesystem_helper test/test_filesystem_helper.cpp)
+  ament_add_gtest(test_filesystem_helper test/test_filesystem_helper.cpp
+    ENV
+      EXPECTED_WORKING_DIRECTORY=$<SHELL_PATH:${CMAKE_CURRENT_BINARY_DIR}>
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  ament_target_dependencies(test_filesystem_helper rcutils)
 
   ament_add_gtest(test_find_and_replace test/test_find_and_replace.cpp)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,9 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_pointer_traits test/test_pointer_traits.cpp)
 
+  ament_add_gtest(test_process test/test_process.cpp)
+  ament_target_dependencies(test_process rcutils)
+
   set(append_library_dirs "$<TARGET_FILE_DIR:${PROJECT_NAME}>")
 
   ament_add_gtest(test_shared_library test/test_shared_library.cpp

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -2,9 +2,9 @@ This document is a declaration of software quality for the `rcpputils` package, 
 
 # `rcpputils` Quality Declaration
 
-The package `rcpputils` claims to be in the **Quality Level 4** category.
+The package `rcpputils` claims to be in the **Quality Level 2** category.
 
-Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 4 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 2 in REP-2004](https://www.ros.org/reps/rep-2004.html).
 
 ## Version Policy [1]
 
@@ -91,12 +91,23 @@ New features are required to have tests before being added.
 
 ### Public API Testing [4.ii]
 
-Each part of the public API have tests, and new additions or changes to the public API require tests before being added.
+Each part of the public API has tests, and new additions or changes to the public API require tests before being added.
 The tests aim to cover both typical usage and corner cases, but are quantified by contributing to code coverage.
 
 ### Coverage [4.iii]
 
-`rcpputils` does not currently track test coverage.
+`rcpputils` follows the recommendations for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#code-coverage), and opts to use line coverage instead of branch coverage.
+
+This includes:
+
+- tracking and reporting line coverage statistics
+- achieving and maintaining a reasonable branch line coverage (90-100%)
+- no lines are manually skipped in coverage calculations
+
+Changes are required to make a best effort to keep or increase coverage before being accepted, but decreases are allowed if properly justified and accepted by reviewers.
+
+Current coverage statistics can be viewed [here](https://ci.ros2.org/job/ci_linux_coverage/lastSuccessfulBuild/cobertura/).
+A description of how coverage statistics are summarized from this page, can be found in the ["ROS 2 Onboarding Guide"](https://index.ros.org/doc/ros2/Contributing/ROS-2-On-boarding-Guide/#note-on-coverage-runs).
 
 ### Performance [4.iv]
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Quality Declaration
 
-This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](QUALITY_DECLARATION.md) for more details.
+This package claims to be in the **Quality Level 2** category, see the [Quality Declaration](QUALITY_DECLARATION.md) for more details.
 
 ## API
 This package currently contains:

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -327,10 +327,15 @@ public:
   */
   path & operator/=(const path & other)
   {
-    this->path_ += kPreferredSeparator + other.string();
-    this->path_as_vector_.insert(
-      std::end(this->path_as_vector_),
-      std::begin(other.path_as_vector_), std::end(other.path_as_vector_));
+    if (other.is_absolute()) {
+      this->path_ = other.path_;
+      this->path_as_vector_ = other.path_as_vector_;
+    } else {
+      this->path_ += kPreferredSeparator + other.string();
+      this->path_as_vector_.insert(
+        std::end(this->path_as_vector_),
+        std::begin(other.path_as_vector_), std::end(other.path_as_vector_));
+    }
     return *this;
   }
 

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -44,6 +44,7 @@
 #ifndef RCPPUTILS__FILESYSTEM_HELPER_HPP_
 #define RCPPUTILS__FILESYSTEM_HELPER_HPP_
 
+#include <limits.h>
 #include <sys/stat.h>
 
 #include <algorithm>
@@ -416,6 +417,33 @@ inline path temp_directory_path()
   }
 #endif
   return path(temp_path);
+}
+
+/**
+ * \brief Return current working directory.
+ *
+ * \return The current working directory.
+ *
+ * \throws std::system_error
+ */
+inline path current_path()
+{
+#ifdef _WIN32
+#ifdef UNICODE
+#error "rcpputils::fs does not support Unicode paths"
+#endif
+  char cwd[MAX_PATH];
+  if (nullptr == _getcwd(cwd, MAX_PATH)) {
+#else
+  char cwd[PATH_MAX];
+  if (nullptr == getcwd(cwd, PATH_MAX)) {
+#endif
+    std::error_code ec{errno, std::system_category()};
+    errno = 0;
+    throw std::system_error{ec, "cannot get current working directory"};
+  }
+
+  return path(cwd);
 }
 
 /**

--- a/include/rcpputils/process.hpp
+++ b/include/rcpputils/process.hpp
@@ -1,0 +1,49 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCPPUTILS__PROCESS_HPP_
+#define RCPPUTILS__PROCESS_HPP_
+
+#include <rcutils/process.h>
+
+#include <string>
+
+namespace rcpputils
+{
+
+/// Retrieve the current executable name.
+/**
+ * This function portably retrieves the current program name and returns
+ * a copy of it.
+ *
+ * This function is thread-safe.
+ *
+ * \return The program name.
+ * \throws std::runtime_error on error
+ */
+std::string get_executable_name()
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  char * executable_name = rcutils_get_executable_name(allocator);
+  if (nullptr == executable_name) {
+    throw std::runtime_error("Failed to get executable name");
+  }
+  std::string ret(executable_name);
+  allocator.deallocate(executable_name, allocator.state);
+  return ret;
+}
+
+}  // namespace rcpputils
+
+#endif  // RCPPUTILS__PROCESS_HPP_

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "rcpputils/filesystem_helper.hpp"
+#include "rcpputils/get_env.hpp"
 
 #ifdef _WIN32
 static constexpr const bool is_win32 = true;
@@ -257,4 +258,11 @@ TEST(TestFilesystemHelper, remove_extension_no_extension)
   auto p = path("foo");
   p = rcpputils::fs::remove_extension(p);
   EXPECT_EQ("foo", p.string());
+}
+
+TEST(TestFilesystemHelper, get_cwd)
+{
+  std::string expected_dir = rcpputils::get_env_var("EXPECTED_WORKING_DIRECTORY");
+  auto p = rcpputils::fs::current_path();
+  EXPECT_EQ(expected_dir, p.string());
 }

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -49,12 +49,21 @@ std::string build_directory_path()
 
 TEST(TestFilesystemHelper, join_path)
 {
-  auto p = path("foo") / path("bar");
+  {
+    auto p = path("foo") / path("bar");
+    if (is_win32) {
+      EXPECT_EQ("foo\\bar", p.string());
+    } else {
+      EXPECT_EQ("foo/bar", p.string());
+    }
+  }
 
   if (is_win32) {
-    EXPECT_EQ("foo\\bar", p.string());
+    auto p = path("foo") / path("C:\\bar");
+    EXPECT_EQ("C:\\bar", p.string());
   } else {
-    EXPECT_EQ("foo/bar", p.string());
+    auto p = path("foo") / path("/bar");
+    EXPECT_EQ("/bar", p.string());
   }
 }
 

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -70,9 +70,48 @@ TEST(TestFilesystemHelper, join_path)
 
 TEST(TestFilesystemHelper, parent_path)
 {
-  auto p = path("my") / path("path");
-
-  EXPECT_EQ(p.parent_path().string(), path("my").string());
+  {
+    auto p = path("my") / path("path");
+    EXPECT_EQ(p.parent_path().string(), path("my").string());
+  }
+  {
+    auto p = path("foo");
+    EXPECT_EQ(p.parent_path().string(), ".");
+  }
+  {
+    if (is_win32) {
+      {
+        auto p = path("C:\\foo");
+        EXPECT_EQ(p.parent_path().string(), "C:\\");
+      }
+      {
+        auto p = path("\\foo");
+        EXPECT_EQ(p.parent_path().string(), "\\");
+      }
+    } else {
+      auto p = path("/foo");
+      EXPECT_EQ(p.parent_path().string(), "/");
+    }
+  }
+  {
+    if (is_win32) {
+      {
+        auto p = path("C:\\");
+        EXPECT_EQ(p.parent_path().string(), "C:\\");
+      }
+      {
+        auto p = path("\\");
+        EXPECT_EQ(p.parent_path().string(), "\\");
+      }
+    } else {
+      auto p = path("/");
+      EXPECT_EQ(p.parent_path().string(), "/");
+    }
+  }
+  {
+    auto p = path("");
+    EXPECT_EQ(p.parent_path().string(), "");
+  }
 }
 
 TEST(TestFilesystemHelper, to_native_path)
@@ -124,6 +163,14 @@ TEST(TestFilesystemHelper, is_absolute)
     }
     {
       auto p = path("C:/foo/bar/baz");
+      EXPECT_TRUE(p.is_absolute());
+    }
+    {
+      auto p = path("\\foo\\bar\\baz");
+      EXPECT_TRUE(p.is_absolute());
+    }
+    {
+      auto p = path("/foo/bar/baz");
       EXPECT_TRUE(p.is_absolute());
     }
     {
@@ -185,6 +232,31 @@ TEST(TestFilesystemHelper, is_empty)
 {
   auto p = path("");
   EXPECT_TRUE(p.empty());
+}
+
+TEST(TestFilesystemHelper, exists)
+{
+  {
+    auto p = path("");
+    EXPECT_FALSE(p.exists());
+  }
+  {
+    auto p = path(".");
+    EXPECT_TRUE(p.exists());
+  }
+  {
+    auto p = path("..");
+    EXPECT_TRUE(p.exists());
+  }
+  {
+    if (is_win32) {
+      auto p = path("\\");
+      EXPECT_TRUE(p.exists());
+    } else {
+      auto p = path("/");
+      EXPECT_TRUE(p.exists());
+    }
+  }
 }
 
 /**

--- a/test/test_pointer_traits.cpp
+++ b/test/test_pointer_traits.cpp
@@ -126,4 +126,7 @@ TEST(TestPointerTraits, remove_pointer) {
   EXPECT_TRUE(b_cuptr);
   EXPECT_TRUE(b_cvuptr);
   EXPECT_TRUE(b_cvuptrc);
+
+  delete ptr;
+  delete cptrc;
 }

--- a/test/test_process.cpp
+++ b/test/test_process.cpp
@@ -1,0 +1,23 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "rcpputils/process.hpp"
+
+TEST(TestProcess, test_get_executable_name) {
+  EXPECT_EQ("test_process", rcpputils::get_executable_name());
+}


### PR DESCRIPTION
I believe all commits on `master` can be backported to `foxy`. With approval, I will fast-forward merge `master` into `foxy`. Of all the commits, the only code change not explicitly labeled for backport is #70 (though I don't see any issue in backporting it).

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11219)](http://ci.ros2.org/job/ci_linux/11219/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6490)](http://ci.ros2.org/job/ci_linux-aarch64/6490/)
* macOS [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9199)](https://ci.ros2.org/job/ci_osx/9199/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11136)](http://ci.ros2.org/job/ci_windows/11136/)