### PR TITLE
Bump actions versions and add ament_package dependency workaround

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
-    - uses: ros-tooling/setup-ros@0.0.13
-    - uses: ros-tooling/action-ros-lint@0.0.5
+    - uses: ros-tooling/setup-ros@0.0.22
+    - uses: ros-tooling/action-ros-lint@0.0.6
       with:
         linter: copyright
         package-name: rcpputils
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
-    - uses: ros-tooling/setup-ros@0.0.13
-    - uses: ros-tooling/action-ros-lint@0.0.5
+    - uses: ros-tooling/setup-ros@0.0.22
+    - uses: ros-tooling/action-ros-lint@0.0.6
       with:
         linter: xmllint
         package-name: rcpputils
@@ -35,8 +35,8 @@ jobs:
           linter: [cppcheck, cpplint, uncrustify]
     steps:
     - uses: actions/checkout@v1
-    - uses: ros-tooling/setup-ros@0.0.13
-    - uses: ros-tooling/action-ros-lint@0.0.5
+    - uses: ros-tooling/setup-ros@0.0.22
+    - uses: ros-tooling/action-ros-lint@0.0.6
       with:
         linter: ${{ matrix.linter }}
         package-name: rcpputils

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: ros-tooling/setup-ros@0.0.22
     # workaround to ensure ament_package dependency is installed
-    - run: python3 -m pip install -U --force-reinstall importlib-resources
+    - run: python3 -m pip install -U --force-reinstall importlib-resources importlib-metadata
     - uses: ros-tooling/action-ros-ci@0.0.17
       with:
         package-name: rcpputils

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,11 @@ jobs:
       matrix:
           os: [ubuntu-18.04]
     steps:
-    - uses: ros-tooling/setup-ros@0.0.13
-    - uses: ros-tooling/action-ros-ci@0.0.13
+    - uses: ros-tooling/setup-ros@0.0.22
+    - uses: ros-tooling/action-ros-ci@0.0.17
       with:
         package-name: rcpputils
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: colcon-logs
         path: ros_ws/log

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
           os: [ubuntu-18.04]
     steps:
     - uses: ros-tooling/setup-ros@0.0.22
+    # workaround to ensure ament_package dependency is installed
     - run: python3 -m pip install -U --force-reinstall importlib-resources
     - uses: ros-tooling/action-ros-ci@0.0.17
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,11 @@ jobs:
           os: [ubuntu-18.04]
     steps:
     - uses: ros-tooling/setup-ros@0.0.22
+    - run: python3 -m pip install -U --force-reinstall importlib-resources
     - uses: ros-tooling/action-ros-ci@0.0.17
       with:
         package-name: rcpputils
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v1
       with:
         name: colcon-logs
         path: ros_ws/log


### PR DESCRIPTION
Workaround that fixes #76  

 - bump setup-ros to 0.0.22 
 - bump action-ros-lint to 0.0.6
 - bump action-ros-ci to 0.0.17
 - manually install `importlib-resources` and `importlib-metadata` dependencies

Signed-off-by: Devin Bonnie <dbbonnie@amazon.com>