### PR TITLE
filesystem helpers: adding remove_all to remove non-empty directories

### DIFF
--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -570,9 +570,7 @@ inline bool remove_all(const path & p)
   auto ret = SHFileOperation(&file_options);
   delete[] temp_dir;
 
-  if (0 != ret) {
-    return false;
-  }
+  return 0 == ret && false == file_options.fAnyOperationsAborted;
 #else
   DIR * dir = opendir(p.string().c_str());
   struct dirent * directory_entry;
@@ -592,9 +590,8 @@ inline bool remove_all(const path & p)
   closedir(dir);
   // directory is empty now, call remove
   remove(p);
-#endif
-
   return !rcpputils::fs::exists(p);
+#endif
 }
 
 /**

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -313,7 +313,6 @@ TEST(TestFilesystemHelper, filesystem_manipulation)
   for (auto i = 0u; i < num_files; ++i) {
     std::string file_name = std::string("test_file") + std::to_string(i) + ".txt";
     auto file = dir / file_name;
-    uint64_t expected_file_size = 0;
     {
       std::ofstream output_buffer{file.string()};
       output_buffer << "test" << i;

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -302,6 +302,41 @@ TEST(TestFilesystemHelper, filesystem_manipulation)
   EXPECT_TRUE(rcpputils::fs::exists(temp_dir));
   EXPECT_TRUE(rcpputils::fs::remove(temp_dir));
   EXPECT_TRUE(rcpputils::fs::remove(temp_dir.parent_path()));
+
+  // Remove directory and its content
+  EXPECT_FALSE(rcpputils::fs::exists(dir));
+  EXPECT_TRUE(rcpputils::fs::create_directories(dir));
+  EXPECT_TRUE(rcpputils::fs::exists(dir));
+  EXPECT_TRUE(rcpputils::fs::is_directory(dir));
+
+  auto num_files = 10u;
+  for (auto i = 0u; i < num_files; ++i) {
+    std::string file_name = std::string("test_file") + std::to_string(i) + ".txt";
+    auto file = dir / file_name;
+    uint64_t expected_file_size = 0;
+    {
+      std::ofstream output_buffer{file.string()};
+      output_buffer << "test" << i;
+      expected_file_size = static_cast<uint64_t>(output_buffer.tellp());
+    }
+
+    ASSERT_TRUE(rcpputils::fs::exists(file));
+    ASSERT_FALSE(rcpputils::fs::remove_all(file));
+    // File still has to be existing
+    ASSERT_TRUE(rcpputils::fs::exists(file));
+  }
+
+  // remove shall fail given that directory is not empty
+  ASSERT_FALSE(rcpputils::fs::remove(dir));
+
+  rcpputils::fs::remove_all(dir);
+
+  for (auto i = 0u; i < num_files; ++i) {
+    std::string file_name = std::string("test_file") + std::to_string(i) + ".txt";
+    auto file = dir / file_name;
+    ASSERT_FALSE(rcpputils::fs::exists(file));
+  }
+  ASSERT_FALSE(rcpputils::fs::exists(dir));
 }
 
 TEST(TestFilesystemHelper, remove_extension)

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -303,9 +303,31 @@ TEST(TestFilesystemHelper, filesystem_manipulation)
   EXPECT_TRUE(rcpputils::fs::remove(temp_dir));
   EXPECT_TRUE(rcpputils::fs::remove(temp_dir.parent_path()));
 
-  // Remove directory and its content
+  // Remove empty directory
   EXPECT_FALSE(rcpputils::fs::exists(dir));
   EXPECT_TRUE(rcpputils::fs::create_directories(dir));
+  EXPECT_TRUE(rcpputils::fs::exists(dir));
+  EXPECT_TRUE(rcpputils::fs::is_directory(dir));
+  EXPECT_TRUE(rcpputils::fs::remove_all(dir));
+  EXPECT_FALSE(rcpputils::fs::is_directory(dir));
+
+  // Remove non-existing directory
+  EXPECT_FALSE(rcpputils::fs::remove_all(rcpputils::fs::path("some") / "nonsense" / "dir"));
+
+  EXPECT_FALSE(rcpputils::fs::exists(dir));
+  EXPECT_TRUE(rcpputils::fs::create_directories(dir));
+
+  // Remove single file with remove_all
+  file = dir / "remove_all_single_file.txt";
+  {
+    std::ofstream output_buffer{file.string()};
+    output_buffer << "some content";
+  }
+  ASSERT_TRUE(rcpputils::fs::exists(file));
+  ASSERT_TRUE(rcpputils::fs::is_regular_file(file));
+  EXPECT_TRUE(rcpputils::fs::remove_all(file));
+
+  // Remove directory and its content
   EXPECT_TRUE(rcpputils::fs::exists(dir));
   EXPECT_TRUE(rcpputils::fs::is_directory(dir));
 
@@ -316,19 +338,13 @@ TEST(TestFilesystemHelper, filesystem_manipulation)
     {
       std::ofstream output_buffer{file.string()};
       output_buffer << "test" << i;
-      expected_file_size = static_cast<uint64_t>(output_buffer.tellp());
     }
-
-    ASSERT_TRUE(rcpputils::fs::exists(file));
-    ASSERT_FALSE(rcpputils::fs::remove_all(file));
-    // File still has to be existing
-    ASSERT_TRUE(rcpputils::fs::exists(file));
   }
 
   // remove shall fail given that directory is not empty
   ASSERT_FALSE(rcpputils::fs::remove(dir));
 
-  rcpputils::fs::remove_all(dir);
+  EXPECT_TRUE(rcpputils::fs::remove_all(dir));
 
   for (auto i = 0u; i < num_files; ++i) {
     std::string file_name = std::string("test_file") + std::to_string(i) + ".txt";


### PR DESCRIPTION
fixes #62 

This is a transfer from what we're using at rosbag2: https://github.com/ros2/rosbag2/blob/master/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp#L59-L99

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11350)](http://ci.ros2.org/job/ci_linux/11350/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6582)](http://ci.ros2.org/job/ci_linux-aarch64/6582/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9307)](http://ci.ros2.org/job/ci_osx/9307/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11243)](http://ci.ros2.org/job/ci_windows/11243/)