### PR TITLE
Add cstring include for strcmp

### DIFF
--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -48,6 +48,7 @@
 #include <sys/stat.h>
 
 #include <algorithm>
+#include <cstring>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Getting a build failure from source because of a call to `strcmp`, which is in header `cstring` (or `string.h`).

https://github.com/ros2/rcpputils/blob/a2e52e01fb93054d6bee51d0495917deaa6aa7f4/include/rcpputils/filesystem_helper.hpp#L579

Signed-off-by: Hunter L. Allen <hunter.allen@ghostrobotics.io>