### PR TITLE
Split get_env_var() into header and implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ ament_export_include_directories(include)
 add_library(${PROJECT_NAME}
   src/asserts.cpp
   src/find_library.cpp
+  src/get_env.cpp
   src/shared_library.cpp)
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
@@ -69,6 +70,7 @@ if(BUILD_TESTING)
       NORMAL_TEST=foo
   )
   ament_target_dependencies(test_get_env rcutils)
+  target_link_libraries(test_get_env ${PROJECT_NAME})
 
   ament_add_gtest(test_scope_exit test/test_scope_exit.cpp)
   target_link_libraries(test_scope_exit ${PROJECT_NAME})
@@ -80,6 +82,7 @@ if(BUILD_TESTING)
       EXPECTED_WORKING_DIRECTORY=$<SHELL_PATH:${CMAKE_CURRENT_BINARY_DIR}>
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
   ament_target_dependencies(test_filesystem_helper rcutils)
+  target_link_libraries(test_filesystem_helper ${PROJECT_NAME})
 
   ament_add_gtest(test_find_and_replace test/test_find_and_replace.cpp)
 

--- a/include/rcpputils/get_env.hpp
+++ b/include/rcpputils/get_env.hpp
@@ -46,6 +46,7 @@ namespace rcpputils
  * \return The value of the environment variable if it exists, or "".
  * \throws std::runtime_error on error
  */
+RCPPUTILS_PUBLIC
 std::string get_env_var(const char * env_var);
 
 }  // namespace rcpputils

--- a/src/get_env.cpp
+++ b/src/get_env.cpp
@@ -30,24 +30,24 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#ifndef RCPPUTILS__GET_ENV_HPP_
-#define RCPPUTILS__GET_ENV_HPP_
-
+#include <stdexcept>
 #include <string>
 
-#include "rcpputils/visibility_control.hpp"
+#include "rcutils/get_env.h"
+
+#include "rcpputils/get_env.hpp"
 
 namespace rcpputils
 {
 
-/// Retrieve the value of the given environment variable if it exists, or "".
-/*
- * \param[in] env_var the name of the environment variable
- * \return The value of the environment variable if it exists, or "".
- * \throws std::runtime_error on error
- */
-std::string get_env_var(const char * env_var);
+std::string get_env_var(const char * env_var)
+{
+  const char * value{};
+  const char * err = rcutils_get_env(env_var, &value);
+  if (err) {
+    throw std::runtime_error(err);
+  }
+  return value ? value : "";
+}
 
 }  // namespace rcpputils
-
-#endif  // RCPPUTILS__GET_ENV_HPP_


### PR DESCRIPTION
Closes #82

I noticed that it wasn't declared as `RCPPUTILS_PUBLIC` even if `"rcpputils/visibility_control.hpp"` was `#include`d, so I added it in a separate commit. Let me know if I should remove it.