### PR TITLE
Add clamp header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,8 @@ if(BUILD_TESTING)
   set_tests_properties(test_find_library PROPERTIES
     ENVIRONMENT
       "_TEST_LIBRARY_DIR=$<TARGET_FILE_DIR:test_library>;_TEST_LIBRARY=$<TARGET_FILE:test_library>")
+
+  ament_add_gtest(test_clamp test/test_clamp.cpp)
 endif()
 
 ament_package()

--- a/include/rcppmath/clamp.hpp
+++ b/include/rcppmath/clamp.hpp
@@ -1,0 +1,46 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*! \file clamp.hpp
+ * \brief Restrict a value between two bounds
+ */
+
+#ifndef RCPPMATH__CLAMP_HPP_
+#define RCPPMATH__CLAMP_HPP_
+
+#include <cassert>
+
+namespace rcppmath
+{
+
+// Implementation from https://en.cppreference.com/w/cpp/algorithm/clamp
+// @note Capturing the result of clamp by reference if one of the parameters
+//       is rvalue produces a dangling reference if that parameter is returned
+template<class T>
+constexpr const T & clamp(const T & v, const T & lo, const T & hi)
+{
+  assert(!(hi < lo) );
+  return (v < lo) ? lo : (hi < v) ? hi : v;
+}
+
+template<class T, class Compare>
+constexpr const T & clamp(const T & v, const T & lo, const T & hi, Compare comp)
+{
+  assert(!comp(hi, lo) );
+  return comp(v, lo) ? lo : comp(hi, v) ? hi : v;
+}
+
+}  // namespace rcppmath
+
+#endif  // RCPPMATH__CLAMP_HPP_

--- a/include/rcppmath/clamp.hpp
+++ b/include/rcppmath/clamp.hpp
@@ -23,10 +23,18 @@
 
 namespace rcppmath
 {
-
-// Implementation from https://en.cppreference.com/w/cpp/algorithm/clamp
-// @note Capturing the result of clamp by reference if one of the parameters
-//       is rvalue produces a dangling reference if that parameter is returned
+/// If v compares less than lo, returns lo; otherwise if hi compares less
+//  than v, returns hi; otherwise returns v. Uses operator< to compare the values
+/**
+ * \param[in] v the value to clamp
+ * \param[in] lo the lower boundary
+ * \param[in] hi the higher boundary
+ * \return Reference to lo if v is less than lo, reference to hi if hi is less than v, otherwise
+ * reference to v.
+ * \note Implementation from https://en.cppreference.com/w/cpp/algorithm/clamp
+ * \warning Capturing the result of clamp by reference if one of the parameters is rvalue produces
+ *  a dangling reference if that parameter is returned
+ **/
 template<class T>
 constexpr const T & clamp(const T & v, const T & lo, const T & hi)
 {
@@ -34,6 +42,11 @@ constexpr const T & clamp(const T & v, const T & lo, const T & hi)
   return (v < lo) ? lo : (hi < v) ? hi : v;
 }
 
+/// Like the function above, but uses comp to compare the values.
+/**
+ * \param[in] comp Comparison object that returns true if the first argument is
+ * less than the second
+ **/
 template<class T, class Compare>
 constexpr const T & clamp(const T & v, const T & lo, const T & hi, Compare comp)
 {

--- a/test/test_clamp.cpp
+++ b/test/test_clamp.cpp
@@ -1,0 +1,52 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <limits>
+
+#include "rcppmath/clamp.hpp"
+
+TEST(test_clamp, test_basic) {
+  EXPECT_EQ(rcppmath::clamp(1, 2, 5), 2);
+  EXPECT_EQ(rcppmath::clamp(2, 2, 5), 2);
+  EXPECT_EQ(rcppmath::clamp(5, 2, 5), 5);
+  EXPECT_EQ(rcppmath::clamp(6, 2, 5), 5);
+  EXPECT_EQ(rcppmath::clamp(3, 2, 5), 3);
+  EXPECT_EQ(rcppmath::clamp(4, 2, 5), 4);
+}
+
+TEST(test_clamp, test_cmp) {
+  auto cmp = [](const int & a, const int & b)
+    {
+      return a < b;
+    };
+  EXPECT_EQ(rcppmath::clamp(1, 2, 5, cmp), 2);
+  EXPECT_EQ(rcppmath::clamp(2, 2, 5, cmp), 2);
+  EXPECT_EQ(rcppmath::clamp(5, 2, 5, cmp), 5);
+  EXPECT_EQ(rcppmath::clamp(6, 2, 5, cmp), 5);
+  EXPECT_EQ(rcppmath::clamp(3, 2, 5, cmp), 3);
+  EXPECT_EQ(rcppmath::clamp(4, 2, 5, cmp), 4);
+}
+TEST(test_clamp, test_limits) {
+  EXPECT_EQ(rcppmath::clamp(std::numeric_limits<double>::infinity(), 0.0, 1.0), 1.0);
+  EXPECT_EQ(rcppmath::clamp(-std::numeric_limits<double>::infinity(), 0.0, 1.0), 0.0);
+
+  // Nan's are not limited by clamp, and return a nan, which is not comparable to itself
+  EXPECT_NE(rcppmath::clamp(std::numeric_limits<double>::quiet_NaN(), 0.0, 1.0), 0.0);
+  EXPECT_NE(rcppmath::clamp(std::numeric_limits<double>::quiet_NaN(), 0.0, 1.0), 1.0);
+  EXPECT_NE(
+    rcppmath::clamp(
+      std::numeric_limits<double>::quiet_NaN(), 0.0, 1.0),
+    std::numeric_limits<double>::quiet_NaN());
+}


### PR DESCRIPTION
Avoids temporarily avoids using boost or C++17

In the end I did not need to create another library target for this, since all templates. But I've put in the separate directory as discussed.

Fixes #84 

