### PR TITLE
ensure -fPIC is used when building a static lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # enables building a static library but later link it into a dynamic library
+  add_compile_options(-fPIC)
+endif()
 if(NOT WIN32)
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()


### PR DESCRIPTION
Related to ros2/ros2#635.