### PR TITLE
Revert "Make sure that an existing path is a directory for create_directories"

### DIFF
--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -511,7 +511,7 @@ inline bool create_directories(const path & p)
 #endif
     }
   }
-  return p_built.is_directory() && status == 0;
+  return status == 0;
 }
 
 /**

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -286,7 +286,6 @@ TEST(TestFilesystemHelper, filesystem_manipulation)
   EXPECT_TRUE(rcpputils::fs::exists(file));
   EXPECT_TRUE(rcpputils::fs::is_regular_file(file));
   EXPECT_FALSE(rcpputils::fs::is_directory(file));
-  EXPECT_FALSE(rcpputils::fs::create_directories(file));
   EXPECT_GE(rcpputils::fs::file_size(file), expected_file_size);
   EXPECT_THROW(rcpputils::fs::file_size(dir), std::system_error) <<
     "file_size is only applicable for files!";


### PR DESCRIPTION
Reverts ros2/rcpputils#95

@christophebedard I'm reverting this because it is causing test failures in rosbag, see:

https://ci.ros2.org/job/ci_linux/12453/testReport/

I didn't run CI correctly so we didn't see the break.

@clalancette @jacobperron FYI