### PR TITLE
create_directories returns true if the path is empty

### DIFF
--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -497,6 +497,10 @@ inline bool create_directories(const path & p)
   path p_built;
   int status = 0;
 
+  if (p.empty()) {
+    return true;
+  }
+
   for (auto it = p.cbegin(); it != p.cend() && status == 0; ++it) {
     if (!p_built.empty() || it->empty()) {
       p_built /= *it;

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -511,7 +511,7 @@ inline bool create_directories(const path & p)
 #endif
     }
   }
-  return status == 0;
+  return p_built.is_directory() && status == 0;
 }
 
 /**

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -286,6 +286,7 @@ TEST(TestFilesystemHelper, filesystem_manipulation)
   EXPECT_TRUE(rcpputils::fs::exists(file));
   EXPECT_TRUE(rcpputils::fs::is_regular_file(file));
   EXPECT_FALSE(rcpputils::fs::is_directory(file));
+  EXPECT_FALSE(rcpputils::fs::create_directories(file));
   EXPECT_GE(rcpputils::fs::file_size(file), expected_file_size);
   EXPECT_THROW(rcpputils::fs::file_size(dir), std::system_error) <<
     "file_size is only applicable for files!";


### PR DESCRIPTION
fix https://github.com/ros2/rcpputils/issues/94, and address https://github.com/ros2/rcpputils/pull/96