### PR TITLE
overload functions for has_symbol and get_symbol with raw string literal

### DIFF
--- a/include/rcpputils/shared_library.hpp
+++ b/include/rcpputils/shared_library.hpp
@@ -60,6 +60,13 @@ public:
    */
   RCPPUTILS_PUBLIC
   bool
+  has_symbol(const char * symbol_name);
+
+  /**
+   * @copydoc SharedLibrary::has_symbol(const char *)
+   */
+  RCPPUTILS_PUBLIC
+  bool
   has_symbol(const std::string & symbol_name);
 
   /// Return shared library symbol pointer.
@@ -68,6 +75,13 @@ public:
    * \return shared library symbol pointer, if the symbol doesn't exist then throws a
    * runtime_error exception
    * \throws std::runtime_error if the symbol doesn't exist in the shared library
+   */
+  RCPPUTILS_PUBLIC
+  void *
+  get_symbol(const char * symbol_name);
+
+  /**
+   * @copydoc SharedLibrary::get_symbol(const char *)
    */
   RCPPUTILS_PUBLIC
   void *

--- a/src/shared_library.cpp
+++ b/src/shared_library.cpp
@@ -60,9 +60,9 @@ void SharedLibrary::unload_library()
   }
 }
 
-void * SharedLibrary::get_symbol(const std::string & symbol_name)
+void * SharedLibrary::get_symbol(const char * symbol_name)
 {
-  void * lib_symbol = rcutils_get_symbol(&lib, symbol_name.c_str());
+  void * lib_symbol = rcutils_get_symbol(&lib, symbol_name);
 
   if (!lib_symbol) {
     std::string rcutils_error_str(rcutils_get_error_string().str);
@@ -72,9 +72,19 @@ void * SharedLibrary::get_symbol(const std::string & symbol_name)
   return lib_symbol;
 }
 
+void * SharedLibrary::get_symbol(const std::string & symbol_name)
+{
+  return get_symbol(symbol_name.c_str());
+}
+
+bool SharedLibrary::has_symbol(const char * symbol_name)
+{
+  return rcutils_has_symbol(&lib, symbol_name);
+}
+
 bool SharedLibrary::has_symbol(const std::string & symbol_name)
 {
-  return rcutils_has_symbol(&lib, symbol_name.c_str());
+  return has_symbol(symbol_name.c_str());
 }
 
 std::string SharedLibrary::get_library_path()

--- a/test/test_shared_library.cpp
+++ b/test/test_shared_library.cpp
@@ -28,7 +28,11 @@ TEST(test_shared_library, valid_load) {
 
     EXPECT_TRUE(library->has_symbol("print_name"));
 
+    EXPECT_TRUE(library->has_symbol(std::string("print_name")));
+
     EXPECT_TRUE(library->get_symbol("print_name") != NULL);
+
+    EXPECT_TRUE(library->get_symbol(std::string("print_name")) != NULL);
   } catch (...) {
     FAIL();
   }


### PR DESCRIPTION
As rmw_implementation uses parameter `const char *` to call these functions, it is best to provide overloaded functions in `const char*`.

Signed-off-by: Chen Lihui <lihui.chen@sony.com>