### PR TITLE
Add an ASSERT to the pointer traits tests.

### DIFF
--- a/test/test_pointer_traits.cpp
+++ b/test/test_pointer_traits.cpp
@@ -22,6 +22,7 @@
 TEST(TestPointerTraits, is_pointer) {
   auto ptr = new int(13);
   auto ptr_ptr = &ptr;
+  ASSERT_TRUE(ptr_ptr == &ptr);  // to quiet clang static analysis
   const auto * const cptrc = new int(13);
   auto sptr = std::make_shared<int>(13);
   const auto csptr = std::make_shared<int>(13);
@@ -89,6 +90,7 @@ TEST(TestPointerTraits, remove_pointer) {
   auto non_ptr = 13;
   auto ptr = new int(13);
   auto ptr_ptr = &ptr;
+  ASSERT_TRUE(ptr_ptr == &ptr);  // to quiet clang static analysis
   const auto * const cptrc = new int(13);
   auto sptr = std::make_shared<int>(13);
   const auto csptr = std::make_shared<int>(13);


### PR DESCRIPTION
What's happening here is that we are using the initialization
of the pointer to initialize the "auto" type of the variable,
and then using compile-time checks to check on it.  Because
of this, clang static analysis thinks that the variable is
unused (which it is, at runtime).  Since that is not the
purpose of the test, just put a bogus ASSERT_TRUE in that uses
the variable and quiets clang static analysis.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>