### PR TITLE
Fix working with filesystem parent paths.

### DIFF
--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -277,10 +277,10 @@ public:
 
     path parent;
     for (auto it = this->cbegin(); it != --this->cend(); ++it) {
-      if (parent.empty() && !this->is_absolute()) {
-        // This handles the case where we are dealing with a relative path;
-        // we don't want a separator at the beginning, so just copy the piece
-        // directly.
+      if (parent.empty() && (!this->is_absolute() || this->is_absolute_with_drive_letter())) {
+        // This handles the case where we are dealing with a relative path or
+        // the Windows drive letter; in both cases we don't want a separator at
+        // the beginning, so just copy the piece directly.
         parent = *it;
       } else {
         parent /= *it;

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -103,10 +103,11 @@ public:
    * \param p A string path split by the platform's string path separator.
    */
   path(const std::string & p)  // NOLINT(runtime/explicit): this is a conversion constructor
-  : path_(p), path_as_vector_(split(p, kPreferredSeparator))
+  : path_(p)
   {
     std::replace(path_.begin(), path_.end(), '\\', kPreferredSeparator);
     std::replace(path_.begin(), path_.end(), '/', kPreferredSeparator);
+    path_as_vector_ = split(path_, kPreferredSeparator);
   }
 
   /**

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -392,3 +392,15 @@ TEST(TestFilesystemHelper, get_cwd)
   auto p = rcpputils::fs::current_path();
   EXPECT_EQ(expected_dir, p.string());
 }
+
+TEST(TestFilesystemHelper, parent_absolute_path)
+{
+  rcpputils::fs::path path("/home/foo/bar/baz");
+  ASSERT_EQ(path.string(), "/home/foo/bar/baz");
+
+  rcpputils::fs::path parent = path.parent_path();
+  ASSERT_EQ(parent.string(), "/home/foo/bar");
+
+  rcpputils::fs::path grandparent = parent.parent_path();
+  ASSERT_EQ(grandparent.string(), "/home/foo");
+}

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -396,11 +396,32 @@ TEST(TestFilesystemHelper, get_cwd)
 TEST(TestFilesystemHelper, parent_absolute_path)
 {
   rcpputils::fs::path path("/home/foo/bar/baz");
-  ASSERT_EQ(path.string(), "/home/foo/bar/baz");
+  if (is_win32) {
+    ASSERT_EQ(path.string(), "\\home\\foo\\bar\\baz");
+  } else {
+    ASSERT_EQ(path.string(), "/home/foo/bar/baz");
+  }
 
   rcpputils::fs::path parent = path.parent_path();
-  ASSERT_EQ(parent.string(), "/home/foo/bar");
+  if (is_win32) {
+    ASSERT_EQ(parent.string(), "\\home\\foo\\bar");
+  } else {
+    ASSERT_EQ(parent.string(), "/home/foo/bar");
+  }
 
   rcpputils::fs::path grandparent = parent.parent_path();
-  ASSERT_EQ(grandparent.string(), "/home/foo");
+  if (is_win32) {
+    ASSERT_EQ(grandparent.string(), "\\home\\foo");
+  } else {
+    ASSERT_EQ(grandparent.string(), "/home/foo");
+  }
+
+  if (is_win32) {
+    rcpputils::fs::path win_drive_letter("C:\\home\\foo\\bar");
+    ASSERT_EQ(win_drive_letter.string(), "C:\\home\\foo\\bar");
+    rcpputils::fs::path win_parent = win_drive_letter.parent_path();
+    ASSERT_EQ(win_parent.string(), "C:\\home\\foo");
+    rcpputils::fs::path win_grandparent = win_parent.parent_path();
+    ASSERT_EQ(win_grandparent.string(), "C:\\home");
+  }
 }


### PR DESCRIPTION
I found two separate bugs while working with parent paths:

1.  Asking for the first parent path of an absolute path
would add a duplicate separator at the beginning.  I fixed
this by checking to see if the separator already exists,
and skiping if there is already one.
2.  Asking for the grandparent path of an absolute path
would return a relative path, which is very incorrect.  The
problem here turned out to be that we were not propagating
empty vector pieces from a child to a parent, and so the
grandparent would miss out that it was supposed to be absolute.
Fix this by always adding all pieces to the parents, even
when they are empty.

I also added tests for the above cases.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This is currently blocking the resolution of https://github.com/ros/pluginlib/pull/212 .  I'll run CI on everything above rcpputils just to ensure we aren't breaking something.