### PR TITLE
Make sure to not try to index into an empty path.

### DIFF
--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -359,7 +359,7 @@ public:
       this->path_ = other.path_;
       this->path_as_vector_ = other.path_as_vector_;
     } else {
-      if (this->path_[this->path_.length() - 1] != kPreferredSeparator) {
+      if (this->path_.empty() || this->path_[this->path_.length() - 1] != kPreferredSeparator) {
         // This ensures that we don't put duplicate separators into the path;
         // this can happen, for instance, on absolute paths where the first
         // item in the vector is the empty string.


### PR DESCRIPTION
This was a bug introduced by https://github.com/ros2/rcpputils/pull/112,
but only shows up on Windows Debug for some reason.  Regardless,
we should not try to index into an empty string.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>