### PR TITLE
Fix rcpputils::SharedLibrary tests.

### DIFF
--- a/test/test_shared_library.cpp
+++ b/test/test_shared_library.cpp
@@ -24,7 +24,7 @@ namespace
 
 bool endswith(const std::string & basestring, const std::string & substring)
 {
-  return basestring.length() > substring.length() && basestring.compare(
+  return basestring.length() >= substring.length() && basestring.compare(
     basestring.length() - substring.length(), substring.length(), substring) == 0;
 }
 

--- a/test/test_shared_library.cpp
+++ b/test/test_shared_library.cpp
@@ -19,12 +19,25 @@
 
 #include "rcpputils/shared_library.hpp"
 
+namespace
+{
+
+bool endswith(const std::string & basestring, const std::string & substring)
+{
+  return basestring.length() > substring.length() && basestring.compare(
+    basestring.length() - substring.length(), substring.length(), substring) == 0;
+}
+
+}  // namespace
+
 TEST(test_shared_library, valid_load) {
-  const std::string library_path = rcpputils::get_platform_library_name("dummy_shared_library");
+  const std::string library_name = rcpputils::get_platform_library_name("dummy_shared_library");
 
   try {
-    auto library = std::make_shared<rcpputils::SharedLibrary>(library_path);
-    EXPECT_STREQ(library->get_library_path().c_str(), library_path.c_str());
+    auto library = std::make_shared<rcpputils::SharedLibrary>(library_name);
+
+    EXPECT_TRUE(endswith(library->get_library_path(), library_name)) <<
+      "Expected .../" << library_name << ", got " << library->get_library_path();
 
     EXPECT_TRUE(library->has_symbol("print_name"));
 
@@ -40,17 +53,17 @@ TEST(test_shared_library, valid_load) {
 
 TEST(test_shared_library, failed_test) {
   // loading a library that doesn't exists
-  std::string library_path = rcpputils::get_platform_library_name("error_library");
+  std::string library_name = rcpputils::get_platform_library_name("error_library");
   try {
-    auto library = std::make_shared<rcpputils::SharedLibrary>(library_path);
+    auto library = std::make_shared<rcpputils::SharedLibrary>(library_name);
     FAIL();
   } catch (...) {
   }
 
   // Loading a valid library
-  library_path = rcpputils::get_platform_library_name("dummy_shared_library");
+  library_name = rcpputils::get_platform_library_name("dummy_shared_library");
   try {
-    auto library = std::make_shared<rcpputils::SharedLibrary>(library_path);
+    auto library = std::make_shared<rcpputils::SharedLibrary>(library_name);
 
     // getting and asking for an unvalid symbol
     EXPECT_THROW(library->get_symbol("symbol"), std::runtime_error);
@@ -60,7 +73,7 @@ TEST(test_shared_library, failed_test) {
   }
 
   try {
-    auto library = std::make_shared<rcpputils::SharedLibrary>(library_path);
+    auto library = std::make_shared<rcpputils::SharedLibrary>(library_name);
 
     EXPECT_NO_THROW(library->unload_library());
     EXPECT_THROW(library->unload_library(), std::runtime_error);


### PR DESCRIPTION
As of https://github.com/ros2/rcutils/pull/320, `rcpputils::SharedLibrary::library_path()` returns actual full paths, not names. This patch should get regressions in recent nightlies like https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_debug/1469 solved.

CI up to `rcpputils`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13337)](http://ci.ros2.org/job/ci_linux/13337/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8267)](http://ci.ros2.org/job/ci_linux-aarch64/8267/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11069)](http://ci.ros2.org/job/ci_osx/11069/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13393)](http://ci.ros2.org/job/ci_windows/13393/)
