### PR TITLE
Path join operator is const

### DIFF
--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -186,7 +186,7 @@ public:
   * \param other the string compnoent to concatenate
   * \return The combined path of this and other.
   */
-  RCPPUTILS_PUBLIC path operator/(const std::string & other);
+  RCPPUTILS_PUBLIC path operator/(const std::string & other) const;
 
   /**
   * \brief Append a string component to this path.
@@ -202,7 +202,7 @@ public:
   * \param other the path to append
   * \return The combined path.
   */
-  RCPPUTILS_PUBLIC path operator/(const path & other);
+  RCPPUTILS_PUBLIC path operator/(const path & other) const;
 
   /**
   * \brief Append a string component to this path.

--- a/src/filesystem_helper.cpp
+++ b/src/filesystem_helper.cpp
@@ -214,7 +214,7 @@ path path::extension() const
   return split_fname.size() == 1 ? path("") : path("." + split_fname.back());
 }
 
-path path::operator/(const std::string & other)
+path path::operator/(const std::string & other) const
 {
   return this->operator/(path(other));
 }
@@ -225,7 +225,7 @@ path & path::operator/=(const std::string & other)
   return *this;
 }
 
-path path::operator/(const path & other)
+path path::operator/(const path & other) const
 {
   return path(*this).operator/=(other);
 }

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -66,6 +66,15 @@ TEST(TestFilesystemHelper, join_path)
     auto p = path("foo") / path("/bar");
     EXPECT_EQ("/bar", p.string());
   }
+
+  {
+    // Just expect these join operations to be allowed with const paths
+    const auto p1 = path("foo");
+    auto p1_baz = p1 / "baz";
+
+    const auto p2 = path("bar");
+    auto p1_2 = p1 / p2;
+  }
 }
 
 TEST(TestFilesystemHelper, parent_path)


### PR DESCRIPTION
Noticed this when trying to join some const paths - the / operator is non-mutating, so this won't affect any existing code.

The added test code won't compile without the changed feature code.