### PR TITLE
Add stream operator for paths to make it easier to log

### DIFF
--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -305,6 +305,15 @@ RCPPUTILS_PUBLIC bool remove_all(const path & p);
  */
 RCPPUTILS_PUBLIC path remove_extension(const path & file_path, int n_times = 1);
 
+/**
+* \brief Convert the path to a string for ostream usage, such as in logging or string formatting.
+*
+* \param os The stream to send the path string to
+* \param p The path to stringify
+* \return The ostream, for chaining
+*/
+RCPPUTILS_PUBLIC std::ostream & operator<<(std::ostream & os, const path & p);
+
 }  // namespace fs
 }  // namespace rcpputils
 

--- a/src/filesystem_helper.cpp
+++ b/src/filesystem_helper.cpp
@@ -431,5 +431,11 @@ path remove_extension(const path & file_path, int n_times)
   return new_path;
 }
 
+std::ostream & operator<<(std::ostream & os, const path & p)
+{
+  os << p.string();
+  return os;
+}
+
 }  // namespace fs
 }  // namespace rcpputils

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -425,3 +425,11 @@ TEST(TestFilesystemHelper, parent_absolute_path)
     ASSERT_EQ(win_grandparent.string(), "C:\\home");
   }
 }
+
+TEST(TestFilesystemHelper, stream_operator)
+{
+  path p{"foo"};
+  std::stringstream s;
+  s << "bar" << p;
+  ASSERT_EQ(s.str(), "barfoo");
+}


### PR DESCRIPTION
Usage example: 

```
path p{"/path"};
std::cout << "Using the path " << p << std::endl; // as opposed to having to use p.string()
```