### PR TITLE
Support loading libraries from system library dirs

### DIFF
--- a/src/find_library.cpp
+++ b/src/find_library.cpp
@@ -21,6 +21,8 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <iostream>
+
 
 #include "rcutils/filesystem.h"
 #include "rcutils/get_env.h"
@@ -67,7 +69,7 @@ std::string find_library_path(const std::string & library_name)
       return path;
     }
   }
-  return "";
+  return filename;
 }
 
 }  // namespace rcpputils

--- a/src/find_library.cpp
+++ b/src/find_library.cpp
@@ -21,8 +21,6 @@
 #include <sstream>
 #include <string>
 #include <vector>
-#include <iostream>
-
 
 #include "rcutils/filesystem.h"
 #include "rcutils/get_env.h"


### PR DESCRIPTION
find_library_path will return the plain library name, instead of "". This allows dlopen to try and find the library, rather than throwing an error immediately when the library is not found in LD_LIBRARY_PATH.
This change is important for running with capabilities, because doing so will clean LD_LIBRARY_PATH and would break most of ROS2 if we cannot fall back to the system library search path.
btw, this assumes that the user is either putting directories into the RPATH or otherwise able to add library paths to /etc/ld.so.config. Either of these should work for people who are using setcap and friends.