### PR TITLE
Add create_temp_directory filesystem helper

### DIFF
--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -293,7 +293,7 @@ RCPPUTILS_PUBLIC path current_path();
  * \brief Create a directory with the given path p.
  *
  * This builds directories recursively and will skip directories if they are already created.
- * \return Return true if the directory is created, false otherwise.
+ * \return Return true if the directory already exists or is created, false otherwise.
  */
 RCPPUTILS_PUBLIC bool create_directories(const path & p);
 

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -270,11 +270,13 @@ RCPPUTILS_PUBLIC path temp_directory_path();
  * if the generated filename exists and keeps generating until a new one is found. This guarantees
  * that there will be no existing files in the returned directory.
  *
- * \param parent The parent path of the directory that will be created
  * \param base_name User-specified portion of the created directory
+ * \param parent The parent path of the directory that will be created
  * \return A path to a newly-created directory with base_name and a 6-character unique suffix
  */
-RCPPUTILS_PUBLIC path create_temp_directory(const path & parent, const std::string & base_name);
+RCPPUTILS_PUBLIC path create_temp_directory(
+  const std::string & base_name,
+  const path & parent = temp_directory_path());
 
 /**
  * \brief Return current working directory.

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -266,17 +266,19 @@ RCPPUTILS_PUBLIC path temp_directory_path();
 /**
  * \brief Construct a uniquely named temporary directory, in "parent", with format base_name.XXXXXX
  *
- * The output is guaranteed to be a newly-created directory, the underlying utilities check
- * if the generated filename exists and keeps generating until a new one is found. This guarantees
- * that there will be no existing files in the returned directory.
+ * The output, if successful, is guaranteed to be a newly-created directory.
+ * The underlying utilities check if the generated path name exists until a one is found.
+ * This guarantees that there will be no existing files in the returned directory.
  *
  * \param base_name User-specified portion of the created directory
  * \param parent The parent path of the directory that will be created
  * \return A path to a newly-created directory with base_name and a 6-character unique suffix
+ *
+ * \throws std::system_error If any OS APIs do not succeed.
  */
 RCPPUTILS_PUBLIC path create_temp_directory(
   const std::string & base_name,
-  const path & parent = temp_directory_path());
+  const path & parent_path = temp_directory_path());
 
 /**
  * \brief Return current working directory.

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -264,10 +264,10 @@ RCPPUTILS_PUBLIC bool exists(const path & path_to_check);
 RCPPUTILS_PUBLIC path temp_directory_path();
 
 /**
- * \brief Construct a uniquely named temporary directory, in "parent", with format base_name.XXXXXX
+ * \brief Construct a uniquely named temporary directory, in "parent", with format base_nameXXXXXX
  *
  * The output, if successful, is guaranteed to be a newly-created directory.
- * The underlying utilities check if the generated path name exists until a one is found.
+ * The underlying implementation keeps generating paths until one that does not exist is found.
  * This guarantees that there will be no existing files in the returned directory.
  *
  * \param base_name User-specified portion of the created directory

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -255,12 +255,20 @@ RCPPUTILS_PUBLIC bool exists(const path & path_to_check);
 /**
  * \brief Get a path to a location in the temporary directory, if it's available.
  *
+ * This does not create any directories.
+ * On Windows, this uses "GetTempPathA"
+ * On non-Windows, this prefers the environment variable TMPDIR, falling back to /tmp
+ *
  * \return A path to a directory for storing temporary files and directories.
  */
 RCPPUTILS_PUBLIC path temp_directory_path();
 
 /**
  * \brief Construct a uniquely named temporary directory, in "parent", with format base_name.XXXXXX
+ *
+ * The output is guaranteed to be a newly-created directory, the underlying utilities check
+ * if the generated filename exists and keeps generating until a new one is found. This guarantees
+ * that there will be no existing files in the returned directory.
  *
  * \param parent The parent path of the directory that will be created
  * \param base_name User-specified portion of the created directory

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -260,6 +260,15 @@ RCPPUTILS_PUBLIC bool exists(const path & path_to_check);
 RCPPUTILS_PUBLIC path temp_directory_path();
 
 /**
+ * \brief Construct a uniquely named temporary directory, in "parent", with format base_name.XXXXXX
+ *
+ * \param parent The parent path of the directory that will be created
+ * \param base_name User-specified portion of the created directory
+ * \return A path to a newly-created directory with base_name and a 6-character unique suffix
+ */
+RCPPUTILS_PUBLIC path create_temp_directory(const path & parent, const std::string & base_name);
+
+/**
  * \brief Return current working directory.
  *
  * \return The current working directory.

--- a/src/filesystem_helper.cpp
+++ b/src/filesystem_helper.cpp
@@ -306,7 +306,7 @@ path temp_directory_path()
   return path(temp_path);
 }
 
-path create_temp_directory(const path & parent, const std::string & base_name)
+path create_temp_directory(const std::string & base_name, const path & parent)
 {
   auto template_path = base_name + ".XXXXXX";
 

--- a/src/filesystem_helper.cpp
+++ b/src/filesystem_helper.cpp
@@ -310,6 +310,11 @@ path create_temp_directory(const std::string & base_name, const path & parent_pa
 {
   const auto template_path = base_name + "XXXXXX";
   std::string full_template_str = (parent_path / template_path).string();
+  if (!create_directories(parent_path)) {
+    std::error_code ec{errno, std::system_category()};
+    errno = 0;
+    throw std::system_error(ec, "could not create the parent directory");
+  }
 
 #ifdef _WIN32
   errno_t errcode = _mktemp_s(&full_template_str[0], full_template_str.size() + 1);
@@ -323,11 +328,6 @@ path create_temp_directory(const std::string & base_name, const path & parent_pa
     throw std::system_error(ec, "could not create the temp directory");
   }
 #else
-  if (!create_directories(parent_path)) {
-    std::error_code ec{errno, std::system_category()};
-    errno = 0;
-    throw std::system_error(ec, "could not create the parent directory");
-  }
   const char * dir_name = mkdtemp(&full_template_str[0]);
   if (dir_name == nullptr) {
     std::error_code ec{errno, std::system_category()};

--- a/src/filesystem_helper.cpp
+++ b/src/filesystem_helper.cpp
@@ -306,6 +306,22 @@ path temp_directory_path()
   return path(temp_path);
 }
 
+path create_temp_directory(const path & parent, const std::string & base_name)
+{
+  auto template_path = base_name + ".XXXXXX";
+
+#ifdef _WIN32
+  _mktemp_s(&template_path[0], template_path.size() + 1);
+  const auto final_path = parent / template;
+  create_directories(final_path);
+  return final_path
+#else
+  auto full_template = (parent / template_path).string();
+  const char * dir_name = mkdtemp(&full_template[0]);
+  return path(dir_name);
+#endif
+}
+
 path current_path()
 {
 #ifdef _WIN32

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -446,13 +446,12 @@ TEST(TestFilesystemHelper, stream_operator)
 TEST(TestFilesystemHelper, create_temp_directory)
 {
   const std::string basename = "test_base_name";
-  const auto parent = rcpputils::fs::temp_directory_path();
 
-  const auto tmpdir1 = rcpputils::fs::create_temp_directory(parent, basename);
+  const auto tmpdir1 = rcpputils::fs::create_temp_directory(basename);
   EXPECT_TRUE(tmpdir1.exists());
   EXPECT_TRUE(tmpdir1.is_directory());
 
-  const auto tmpdir2 = rcpputils::fs::create_temp_directory(parent, basename);
+  const auto tmpdir2 = rcpputils::fs::create_temp_directory(basename);
   EXPECT_TRUE(tmpdir2.exists());
   EXPECT_TRUE(tmpdir2.is_directory());
 

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -239,8 +239,11 @@ TEST(TestFilesystemHelper, correct_extension)
 
 TEST(TestFilesystemHelper, is_empty)
 {
-  auto p = path("");
-  EXPECT_TRUE(p.empty());
+  auto p_no_arg = path();
+  EXPECT_TRUE(p_no_arg.empty());
+
+  auto p_empty_string = path("");
+  EXPECT_TRUE(p_empty_string.empty());
 }
 
 TEST(TestFilesystemHelper, exists)

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -472,12 +472,29 @@ TEST(TestFilesystemHelper, create_temp_directory)
     }
   }
 
-  // parent paths
+  // newly created paths
   {
     const auto new_relative = rcpputils::fs::current_path() / "child1" / "child2";
     const auto tmpdir = rcpputils::fs::create_temp_directory("base_name", new_relative);
     EXPECT_TRUE(tmpdir.exists());
     EXPECT_TRUE(tmpdir.is_directory());
     EXPECT_TRUE(rcpputils::fs::remove_all(tmpdir));
+  }
+
+  // edge case inputs
+  {
+    // Provided no base name we should still get a path with the 6 unique template chars
+    const auto tmpdir_emptybase = rcpputils::fs::create_temp_directory("");
+    EXPECT_EQ(tmpdir_emptybase.filename().string().size(), 6u);
+
+    // Empty path doesn't exist and cannott be created
+    EXPECT_THROW(rcpputils::fs::create_temp_directory("basename", path()), std::system_error);
+
+    // With the template string XXXXXX already in the name, it will still be there, the unique
+    // portion is appended to the end.
+    const auto tmpdir_template_in_name = rcpputils::fs::create_temp_directory("base_XXXXXX");
+    EXPECT_TRUE(tmpdir_template_in_name.exists());
+    EXPECT_TRUE(tmpdir_template_in_name.is_directory());
+    EXPECT_EQ(tmpdir_template_in_name.filename().string().rfind("base_XXXXXX", 0), 0u);
   }
 }

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -445,18 +445,39 @@ TEST(TestFilesystemHelper, stream_operator)
 
 TEST(TestFilesystemHelper, create_temp_directory)
 {
-  const std::string basename = "test_base_name";
+  // basic usage
+  {
+    const std::string basename = "test_base_name";
 
-  const auto tmpdir1 = rcpputils::fs::create_temp_directory(basename);
-  EXPECT_TRUE(tmpdir1.exists());
-  EXPECT_TRUE(tmpdir1.is_directory());
+    const auto tmpdir1 = rcpputils::fs::create_temp_directory(basename);
+    EXPECT_TRUE(tmpdir1.exists());
+    EXPECT_TRUE(tmpdir1.is_directory());
 
-  const auto tmpdir2 = rcpputils::fs::create_temp_directory(basename);
-  EXPECT_TRUE(tmpdir2.exists());
-  EXPECT_TRUE(tmpdir2.is_directory());
+    const auto tmpdir2 = rcpputils::fs::create_temp_directory(basename);
+    EXPECT_TRUE(tmpdir2.exists());
+    EXPECT_TRUE(tmpdir2.is_directory());
 
-  EXPECT_NE(tmpdir1.string(), tmpdir2.string());
+    EXPECT_NE(tmpdir1.string(), tmpdir2.string());
 
-  EXPECT_TRUE(rcpputils::fs::remove_all(tmpdir1));
-  EXPECT_TRUE(rcpputils::fs::remove_all(tmpdir2));
+    EXPECT_TRUE(rcpputils::fs::remove_all(tmpdir1));
+    EXPECT_TRUE(rcpputils::fs::remove_all(tmpdir2));
+  }
+
+  // bad names
+  {
+    if (is_win32) {
+      EXPECT_THROW(rcpputils::fs::create_temp_directory("illegalchar?"), std::system_error);
+    } else {
+      EXPECT_THROW(rcpputils::fs::create_temp_directory("base/name"), std::system_error);
+    }
+  }
+
+  // parent paths
+  {
+    const auto new_relative = rcpputils::fs::current_path() / "child1" / "child2";
+    const auto tmpdir = rcpputils::fs::create_temp_directory("base_name", new_relative);
+    EXPECT_TRUE(tmpdir.exists());
+    EXPECT_TRUE(tmpdir.is_directory());
+    EXPECT_TRUE(rcpputils::fs::remove_all(tmpdir));
+  }
 }

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -442,3 +442,22 @@ TEST(TestFilesystemHelper, stream_operator)
   s << "bar" << p;
   ASSERT_EQ(s.str(), "barfoo");
 }
+
+TEST(TestFilesystemHelper, create_temp_directory)
+{
+  const std::string basename = "test_base_name";
+  const auto parent = rcpputils::fs::temp_directory_path();
+
+  const auto tmpdir1 = rcpputils::fs::create_temp_directory(parent, basename);
+  EXPECT_TRUE(tmpdir1.exists());
+  EXPECT_TRUE(tmpdir1.is_directory());
+
+  const auto tmpdir2 = rcpputils::fs::create_temp_directory(parent, basename);
+  EXPECT_TRUE(tmpdir2.exists());
+  EXPECT_TRUE(tmpdir2.is_directory());
+
+  EXPECT_NE(tmpdir1.string(), tmpdir2.string());
+
+  EXPECT_TRUE(rcpputils::fs::remove_all(tmpdir1));
+  EXPECT_TRUE(rcpputils::fs::remove_all(tmpdir2));
+}


### PR DESCRIPTION
Add utility to create formatted temporary directories in a cross-platform way. Useful for test fixtures.

Supports ros2/rosbag2#660