### PR TITLE
Make library attributes visible

### DIFF
--- a/include/rcpputils/find_library.hpp
+++ b/include/rcpputils/find_library.hpp
@@ -26,23 +26,6 @@
 namespace rcpputils
 {
 
-#ifdef _WIN32
-static constexpr char kPathVar[] = "PATH";
-static constexpr char kPathSeparator = ';';
-static constexpr char kSolibPrefix[] = "";
-static constexpr char kSolibExtension[] = ".dll";
-#elif __APPLE__
-static constexpr char kPathVar[] = "DYLD_LIBRARY_PATH";
-static constexpr char kPathSeparator = ':';
-static constexpr char kSolibPrefix[] = "lib";
-static constexpr char kSolibExtension[] = ".dylib";
-#else
-static constexpr char kPathVar[] = "LD_LIBRARY_PATH";
-static constexpr char kPathSeparator = ':';
-static constexpr char kSolibPrefix[] = "lib";
-static constexpr char kSolibExtension[] = ".so";
-#endif
-
 /// Find a library located in the OS's specified environment variable for library paths.
 /**
  *
@@ -57,6 +40,18 @@ static constexpr char kSolibExtension[] = ".so";
  */
 RCPPUTILS_PUBLIC
 std::string find_library_path(const std::string & library_name);
+
+
+/// Create the filename corresponding to the library name.
+/**
+ *
+ * @sa find_library_path() for information about the platform-specific filenames.
+ *
+ * \param[in] library_name Name of the library.
+ * \return The filename for the library.
+ */
+RCPPUTILS_PUBLIC
+std::string filename_for_library(const std::string & library_name);
 
 }  // namespace rcpputils
 

--- a/include/rcpputils/find_library.hpp
+++ b/include/rcpputils/find_library.hpp
@@ -45,7 +45,7 @@ std::string find_library_path(const std::string & library_name);
 /// Create the filename corresponding to the library name.
 /**
  *
- * @sa find_library_path() for information about the platform-specific filenames.
+ * \sa find_library_path() for information about the platform-specific filenames.
  *
  * \param[in] library_name Name of the library.
  * \return The filename for the library.

--- a/include/rcpputils/find_library.hpp
+++ b/include/rcpputils/find_library.hpp
@@ -35,12 +35,22 @@ namespace rcpputils
  *  * Windows: `%PATH%`, `{}.dll`
  *
  * \param[in] library_name Name of the library to find.
- * \return The absolute filesystem path, including the appropriate prefix and extension
+ * \return The absolute filesystem path, including the appropriate prefix and extension, or the
+ * empty string when the library was not found.
  * \throws std::runtime_error if an error is encountered when accessing environment variables.
  */
 RCPPUTILS_PUBLIC
 std::string find_library_path(const std::string & library_name);
 
+/// Construct the filepath for a library given its directory, and checks that it exists.
+/**
+ * \param[in] directory The directory that contains the library.
+ * \param[in] library_name Name of the library to find.
+ * \return The absolute filesystem path, including the appropriate prefix and extension, or the
+ * empty string when the library does not exist.
+ */
+RCPPUTILS_PUBLIC
+std::string path_for_library(const std::string & directory, const std::string & library_name);
 
 /// Create the filename corresponding to the library name.
 /**

--- a/include/rcpputils/find_library.hpp
+++ b/include/rcpputils/find_library.hpp
@@ -26,6 +26,23 @@
 namespace rcpputils
 {
 
+#ifdef _WIN32
+static constexpr char kPathVar[] = "PATH";
+static constexpr char kPathSeparator = ';';
+static constexpr char kSolibPrefix[] = "";
+static constexpr char kSolibExtension[] = ".dll";
+#elif __APPLE__
+static constexpr char kPathVar[] = "DYLD_LIBRARY_PATH";
+static constexpr char kPathSeparator = ':';
+static constexpr char kSolibPrefix[] = "lib";
+static constexpr char kSolibExtension[] = ".dylib";
+#else
+static constexpr char kPathVar[] = "LD_LIBRARY_PATH";
+static constexpr char kPathSeparator = ':';
+static constexpr char kSolibPrefix[] = "lib";
+static constexpr char kSolibExtension[] = ".so";
+#endif
+
 /// Find a library located in the OS's specified environment variable for library paths.
 /**
  *

--- a/src/find_library.cpp
+++ b/src/find_library.cpp
@@ -25,6 +25,7 @@
 #include "rcutils/filesystem.h"
 #include "rcutils/get_env.h"
 
+#include "rcpputils/filesystem_helper.hpp"
 #include "rcpputils/split.hpp"
 #include "rcpputils/get_env.hpp"
 
@@ -65,6 +66,15 @@ std::string find_library_path(const std::string & library_name)
     if (rcutils_is_file(path.c_str())) {
       return path;
     }
+  }
+  return "";
+}
+
+std::string path_for_library(const std::string & directory, const std::string & library_name)
+{
+  auto path = rcpputils::fs::path(directory) / filename_for_library(library_name);
+  if (path.is_regular_file()) {
+    return path.string();
   }
   return "";
 }

--- a/src/find_library.cpp
+++ b/src/find_library.cpp
@@ -69,7 +69,8 @@ std::string find_library_path(const std::string & library_name)
   return "";
 }
 
-std::string filename_for_library(const std::string & library_name) {
+std::string filename_for_library(const std::string & library_name)
+{
   return kSolibPrefix + library_name + kSolibExtension;
 }
 

--- a/src/find_library.cpp
+++ b/src/find_library.cpp
@@ -31,28 +31,6 @@
 namespace rcpputils
 {
 
-namespace
-{
-
-#ifdef _WIN32
-static constexpr char kPathVar[] = "PATH";
-static constexpr char kPathSeparator = ';';
-static constexpr char kSolibPrefix[] = "";
-static constexpr char kSolibExtension[] = ".dll";
-#elif __APPLE__
-static constexpr char kPathVar[] = "DYLD_LIBRARY_PATH";
-static constexpr char kPathSeparator = ':';
-static constexpr char kSolibPrefix[] = "lib";
-static constexpr char kSolibExtension[] = ".dylib";
-#else
-static constexpr char kPathVar[] = "LD_LIBRARY_PATH";
-static constexpr char kPathSeparator = ':';
-static constexpr char kSolibPrefix[] = "lib";
-static constexpr char kSolibExtension[] = ".so";
-#endif
-
-}  // namespace
-
 std::string find_library_path(const std::string & library_name)
 {
   std::string search_path = get_env_var(kPathVar);

--- a/src/find_library.cpp
+++ b/src/find_library.cpp
@@ -31,13 +31,34 @@
 namespace rcpputils
 {
 
+namespace
+{
+
+#ifdef _WIN32
+static constexpr char kPathVar[] = "PATH";
+static constexpr char kPathSeparator = ';';
+static constexpr char kSolibPrefix[] = "";
+static constexpr char kSolibExtension[] = ".dll";
+#elif __APPLE__
+static constexpr char kPathVar[] = "DYLD_LIBRARY_PATH";
+static constexpr char kPathSeparator = ':';
+static constexpr char kSolibPrefix[] = "lib";
+static constexpr char kSolibExtension[] = ".dylib";
+#else
+static constexpr char kPathVar[] = "LD_LIBRARY_PATH";
+static constexpr char kPathSeparator = ':';
+static constexpr char kSolibPrefix[] = "lib";
+static constexpr char kSolibExtension[] = ".so";
+#endif
+
+}  // namespace
+
 std::string find_library_path(const std::string & library_name)
 {
   std::string search_path = get_env_var(kPathVar);
   std::vector<std::string> search_paths = rcpputils::split(search_path, kPathSeparator);
 
-  std::string filename = kSolibPrefix;
-  filename += library_name + kSolibExtension;
+  std::string filename = filename_for_library(library_name);
 
   for (const auto & search_path : search_paths) {
     std::string path = search_path + "/" + filename;
@@ -46,6 +67,10 @@ std::string find_library_path(const std::string & library_name)
     }
   }
   return "";
+}
+
+std::string filename_for_library(const std::string & library_name) {
+  return kSolibPrefix + library_name + kSolibExtension;
 }
 
 }  // namespace rcpputils

--- a/test/test_find_library.cpp
+++ b/test/test_find_library.cpp
@@ -45,7 +45,7 @@ TEST(test_find_library, find_library)
   // Get ground-truth values from CTest properties.
   const auto pair = test_lib_path_and_dir();
   const std::string expected_library_path = pair.first;
-  const std::string test_library_path = pair.second;
+  const char * test_lib_dir = pair.second;
 
   // Set our relevant path variable.
   const char * env_var{};
@@ -80,7 +80,7 @@ TEST(test_find_library, library_path)
   // Get ground-truth values from CTest properties.
   const auto pair = test_lib_path_and_dir();
   const std::string expected_library_path = pair.first;
-  const std::string test_library_path = pair.second;
+  const std::string test_lib_dir = pair.second;
 
   const std::string test_lib_actual = rcpputils::path_for_library(test_lib_dir, "test_library");
   const std::string bad_path = rcpputils::path_for_library(

--- a/test/test_find_library.cpp
+++ b/test/test_find_library.cpp
@@ -15,31 +15,37 @@
 #include <stdlib.h>
 
 #include <string>
+#include <utility>
 
 #include "gtest/gtest.h"
 
 #include "rcutils/get_env.h"
 #include "rcpputils/find_library.hpp"
 
-namespace rcpputils
-{
 namespace
 {
 
-TEST(test_find_library, find_library)
+std::pair<const char *, const char *> test_lib_path_and_dir()
 {
-  // Get ground-truth values from CTest properties.
-  std::string expected_library_path;
-  {
-    const char * _expected_library_path{};
-    EXPECT_EQ(rcutils_get_env("_TEST_LIBRARY", &_expected_library_path), nullptr);
-    EXPECT_NE(_expected_library_path, nullptr);
-    expected_library_path = _expected_library_path;
-  }
+  const char * test_lib_path{};
+  EXPECT_EQ(rcutils_get_env("_TEST_LIBRARY", &test_lib_path), nullptr);
+  EXPECT_NE(test_lib_path, nullptr);
 
   const char * test_lib_dir{};
   EXPECT_EQ(rcutils_get_env("_TEST_LIBRARY_DIR", &test_lib_dir), nullptr);
   EXPECT_NE(test_lib_dir, nullptr);
+
+  return {test_lib_path, test_lib_dir};
+}
+
+}  // anonymous namespace
+
+TEST(test_find_library, find_library)
+{
+  // Get ground-truth values from CTest properties.
+  const auto pair = test_lib_path_and_dir();
+  const std::string expected_library_path = pair.first;
+  const std::string test_library_path = pair.second;
 
   // Set our relevant path variable.
   const char * env_var{};
@@ -59,15 +65,26 @@ TEST(test_find_library, find_library)
 #endif
 
   // Positive test.
-  const std::string test_lib_actual = find_library_path("test_library");
+  const std::string test_lib_actual = rcpputils::find_library_path("test_library");
   EXPECT_EQ(test_lib_actual, expected_library_path);
 
   // (Hopefully) Negative test.
-  const std::string bad_path = find_library_path(
+  const std::string bad_path = rcpputils::find_library_path(
     "this_is_a_junk_libray_name_please_dont_define_this_if_you_do_then_"
     "you_are_really_naughty");
   EXPECT_EQ(bad_path, "");
 }
 
-}  // namespace
-}  // namespace rcpputils
+TEST(test_find_library, library_path)
+{
+  // Get ground-truth values from CTest properties.
+  const auto pair = test_lib_path_and_dir();
+  const std::string expected_library_path = pair.first;
+  const std::string test_library_path = pair.second;
+
+  const std::string test_lib_actual = rcpputils::path_for_library(test_lib_dir, "test_library");
+  const std::string bad_path = rcpputils::path_for_library(
+    test_lib_dir,
+    "highly_unlikely_12_library_34567_name_890.txt.exe");
+  EXPECT_EQ(bad_path, "");
+}


### PR DESCRIPTION
This change was requested in https://github.com/ros2/rclcpp/pull/1452#discussion_r589166427: have a central place for these attributes instead of duplicating them in rclcpp.

Signed-off-by: Nikolai Morin <nikolai.morin@apex.ai>