### PR TITLE
Update includes after rcutils/get_env.h deprecation

### DIFF
--- a/src/filesystem_helper.cpp
+++ b/src/filesystem_helper.cpp
@@ -60,7 +60,7 @@
 #  include <unistd.h>
 #endif
 
-#include "rcutils/get_env.h"
+#include "rcutils/env.h"
 #include "rcpputils/split.hpp"
 
 namespace rcpputils

--- a/src/find_library.cpp
+++ b/src/find_library.cpp
@@ -23,7 +23,6 @@
 #include <vector>
 
 #include "rcutils/filesystem.h"
-#include "rcutils/get_env.h"
 
 #include "rcpputils/filesystem_helper.hpp"
 #include "rcpputils/split.hpp"

--- a/src/get_env.cpp
+++ b/src/get_env.cpp
@@ -33,7 +33,7 @@
 #include <stdexcept>
 #include <string>
 
-#include "rcutils/get_env.h"
+#include "rcutils/env.h"
 
 #include "rcpputils/get_env.hpp"
 

--- a/test/test_find_library.cpp
+++ b/test/test_find_library.cpp
@@ -19,7 +19,7 @@
 
 #include "gtest/gtest.h"
 
-#include "rcutils/get_env.h"
+#include "rcutils/env.h"
 #include "rcpputils/find_library.hpp"
 
 namespace


### PR DESCRIPTION
https://github.com/ros2/rcutils/pull/340 deprecates `rcutils/get_env.h`. This PR doesn't need to wait until the `rcutils` PR is merged, though.

Note that in some cases I simply removed the `#include` since nothing from that header was actually used.