### PR TITLE
migrate rolling mean from ros2_controllers to rcppmath

### DIFF
--- a/include/rcppmath/rolling_mean_accumulator.hpp
+++ b/include/rcppmath/rolling_mean_accumulator.hpp
@@ -1,0 +1,68 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Author: Víctor López
+ */
+
+#ifndef RCPPMATH__ROLLING_MEAN_ACCUMULATOR_HPP_
+#define RCPPMATH__ROLLING_MEAN_ACCUMULATOR_HPP_
+
+#include <cassert>
+#include <vector>
+
+namespace rcppmath
+{
+
+/**
+ * \brief Simplification of boost::accumulators::accumulator_set<double,
+ *  bacc::stats<bacc::tag::rolling_mean>> to avoid dragging boost dependencies
+ *
+ * Computes the mean of the last accumulated elements
+ */
+template<typename T>
+class RollingMeanAccumulator
+{
+public:
+  explicit RollingMeanAccumulator(size_t rolling_window_size)
+  : buffer_(rolling_window_size, 0.0), next_insert_(0),
+    sum_(0.0), buffer_filled_(false)
+  {
+  }
+
+  void accumulate(T val)
+  {
+    sum_ -= buffer_[next_insert_];
+    sum_ += val;
+    buffer_[next_insert_] = val;
+    next_insert_++;
+    buffer_filled_ |= next_insert_ >= buffer_.size();
+    next_insert_ = next_insert_ % buffer_.size();
+  }
+
+  T getRollingMean() const
+  {
+    size_t valid_data_count = buffer_filled_ * buffer_.size() + !buffer_filled_ * next_insert_;
+    assert(valid_data_count > 0);
+    return sum_ / valid_data_count;
+  }
+
+private:
+  std::vector<T> buffer_;
+  size_t next_insert_;
+  T sum_;
+  bool buffer_filled_;
+};
+}  // namespace rcppmath
+#endif  // RCPPMATH__ROLLING_MEAN_ACCUMULATOR_HPP_

--- a/test/test_accumulator.cpp
+++ b/test/test_accumulator.cpp
@@ -1,0 +1,55 @@
+// Copyright 2020 PAL Robotics SL.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <rcppmath/rolling_mean_accumulator.hpp>
+
+#include <gmock/gmock.h>
+#include <cmath>
+#include <memory>
+
+
+TEST(TestAccumulator, test_accumulator)
+{
+  constexpr double THRESHOLD = 1e-12;
+  rcppmath::RollingMeanAccumulator<double> accum(4);
+
+  accum.accumulate(1.);
+  EXPECT_NEAR(1., accum.getRollingMean(), THRESHOLD);
+
+  accum.accumulate(1.);
+  EXPECT_NEAR(1., accum.getRollingMean(), THRESHOLD);
+
+  accum.accumulate(5.);
+  EXPECT_NEAR(7. / 3., accum.getRollingMean(), THRESHOLD);
+
+  accum.accumulate(5.);
+  EXPECT_NEAR(12. / 4., accum.getRollingMean(), THRESHOLD);
+
+  // Start removing old values
+  accum.accumulate(5.);
+  EXPECT_NEAR(16. / 4., accum.getRollingMean(), THRESHOLD);
+
+  accum.accumulate(5.);
+  EXPECT_NEAR(20. / 4., accum.getRollingMean(), THRESHOLD);
+}
+
+TEST(TestAccumulator, spam_accumulator)
+{
+  constexpr double THRESHOLD = 1e-12;
+  rcppmath::RollingMeanAccumulator<double> accum(10);
+  for (int i = 0; i < 10000; ++i) {
+    accum.accumulate(M_PI);
+    EXPECT_NEAR(M_PI, accum.getRollingMean(), THRESHOLD);
+  }
+}


### PR DESCRIPTION
that's a clear copy from ros2_controllers package to rcppmath. This makes more sense so we can leverage this header across multiple packages.

Ideally, I plan to also backport this to galactic and foxy.
fyi @v-lopez