### PR TITLE
Improve `rcppmath` Doxygen documentation

### DIFF
--- a/include/rcppmath/clamp.hpp
+++ b/include/rcppmath/clamp.hpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /*! \file clamp.hpp
- * \brief Restrict a value between two bounds
+ *  \brief Restrict a value between two bounds.
  */
 
 #ifndef RCPPMATH__CLAMP_HPP_
@@ -23,18 +23,19 @@
 
 namespace rcppmath
 {
-/// If v compares less than lo, returns lo; otherwise if hi compares less
-//  than v, returns hi; otherwise returns v. Uses operator< to compare the values
 /**
- * \param[in] v the value to clamp
- * \param[in] lo the lower boundary
- * \param[in] hi the higher boundary
+ * If v compares less than lo, returns lo; otherwise if hi compares less
+ * than v, returns hi; otherwise returns v. Uses operator< to compare the values.
+ *
+ * \param[in] v The value to clamp.
+ * \param[in] lo The lower boundary.
+ * \param[in] hi The higher boundary.
  * \return Reference to lo if v is less than lo, reference to hi if hi is less than v, otherwise
  * reference to v.
- * \note Implementation from https://en.cppreference.com/w/cpp/algorithm/clamp
+ * \note Implementation from https://en.cppreference.com/w/cpp/algorithm/clamp.
  * \warning Capturing the result of clamp by reference if one of the parameters is rvalue produces
- *  a dangling reference if that parameter is returned
- **/
+ *  a dangling reference if that parameter is returned.
+ */
 template<class T>
 constexpr const T & clamp(const T & v, const T & lo, const T & hi)
 {
@@ -42,11 +43,18 @@ constexpr const T & clamp(const T & v, const T & lo, const T & hi)
   return (v < lo) ? lo : (hi < v) ? hi : v;
 }
 
-/// Like the function above, but uses comp to compare the values.
 /**
+ * Performs clamping with a provided Comparison object (comp).
+ *
+ * \param[in] v The value to clamp.
+ * \param[in] lo The lower boundary.
+ * \param[in] hi The higher boundary.
  * \param[in] comp Comparison object that returns true if the first argument is
- * less than the second
- **/
+ * less than the second.
+ * \return Reference to lo if v is less than lo, reference to hi if hi is less than v, otherwise
+ * reference to v.
+ * \sa rcppmath::clamp(const T&, const T&, const T&)
+ */
 template<class T, class Compare>
 constexpr const T & clamp(const T & v, const T & lo, const T & hi, Compare comp)
 {

--- a/include/rcppmath/rolling_mean_accumulator.hpp
+++ b/include/rcppmath/rolling_mean_accumulator.hpp
@@ -26,10 +26,10 @@ namespace rcppmath
 {
 
 /**
- * \brief Simplification of boost::accumulators::accumulator_set<double,
- *  bacc::stats<bacc::tag::rolling_mean>> to avoid dragging boost dependencies.
+ * \brief Computes the mean of the last accumulated elements.
  *
- * Computes the mean of the last accumulated elements.
+ * This is a simplified version of boost's rolling mean accumulator,
+ * written to avoid dragging boost dependencies.
  */
 template<typename T>
 class RollingMeanAccumulator

--- a/include/rcppmath/rolling_mean_accumulator.hpp
+++ b/include/rcppmath/rolling_mean_accumulator.hpp
@@ -29,7 +29,7 @@ namespace rcppmath
  * \brief Computes the mean of the last accumulated elements.
  *
  * This is a simplified version of boost's rolling mean accumulator,
- * written to avoid dragging boost dependencies.
+ * written to avoid dragging in boost dependencies.
  */
 template<typename T>
 class RollingMeanAccumulator

--- a/include/rcppmath/rolling_mean_accumulator.hpp
+++ b/include/rcppmath/rolling_mean_accumulator.hpp
@@ -27,20 +27,30 @@ namespace rcppmath
 
 /**
  * \brief Simplification of boost::accumulators::accumulator_set<double,
- *  bacc::stats<bacc::tag::rolling_mean>> to avoid dragging boost dependencies
+ *  bacc::stats<bacc::tag::rolling_mean>> to avoid dragging boost dependencies.
  *
- * Computes the mean of the last accumulated elements
+ * Computes the mean of the last accumulated elements.
  */
 template<typename T>
 class RollingMeanAccumulator
 {
 public:
+  /**
+   * Constructs the rolling mean accumulator with a specified window size.
+   *
+   * \param[in] rolling_window_size The unsigned integral length of the accumulator's window length.
+   */
   explicit RollingMeanAccumulator(size_t rolling_window_size)
   : buffer_(rolling_window_size, 0.0), next_insert_(0),
     sum_(0.0), buffer_filled_(false)
   {
   }
 
+  /**
+   * Collects the provided value in the accumulator's buffer.
+   *
+   * \param[in] val The value to accumulate.
+   */
   void accumulate(T val)
   {
     sum_ -= buffer_[next_insert_];
@@ -51,6 +61,11 @@ public:
     next_insert_ = next_insert_ % buffer_.size();
   }
 
+  /**
+   * Calculates the rolling mean accumulated insofar.
+   *
+   * \return Rolling mean of the accumulated values.
+   */
   T getRollingMean() const
   {
     size_t valid_data_count = buffer_filled_ * buffer_.size() + !buffer_filled_ * next_insert_;


### PR DESCRIPTION
This PR broadly attempts to make `rcppmath` documentation more detailed, as well as fixes some Doxygen issues that previously prevented `rcppmath` documentation from building correctly using `rosdoc2`.

Specifically:
* Documented rolling mean accumulator methods.
* For the clamping methods:
  * Added `\sa` tag instead of explicitly asking user to "see the other function".
  * nit: Capitalization.

Signed-off-by: Abrar Rahman Protyasha <abrar@openrobotics.org>