### PR TITLE
Add accumulator test to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,8 @@ if(BUILD_TESTING)
       "_TEST_LIBRARY_DIR=$<TARGET_FILE_DIR:test_library>;_TEST_LIBRARY=$<TARGET_FILE:test_library>")
 
   ament_add_gtest(test_clamp test/test_clamp.cpp)
+
+  ament_add_gtest(test_accumulator test/test_accumulator.cpp)
 endif()
 
 ament_package()

--- a/test/test_accumulator.cpp
+++ b/test/test_accumulator.cpp
@@ -12,6 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// To get M_PI on Windows.
+
+#ifdef _MSC_VER
+#ifndef _USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
+#endif
+#endif
+
 #include <rcppmath/rolling_mean_accumulator.hpp>
 
 #include <gtest/gtest.h>

--- a/test/test_accumulator.cpp
+++ b/test/test_accumulator.cpp
@@ -14,7 +14,7 @@
 
 #include <rcppmath/rolling_mean_accumulator.hpp>
 
-#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 #include <cmath>
 #include <memory>
 


### PR DESCRIPTION
The rolling mean accumulator class (and its unit test) was
introduced in #133, but the unit test was not setup correctly
in the CMakeLists.txt file; this patch corrects that.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>
