### PR TITLE
Add new interface for time conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,9 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_join test/test_join.cpp)
 
+  ament_add_gtest(test_time test/test_time.cpp)
+  ament_target_dependencies(test_time rcutils)
+
   ament_add_gtest(test_env test/test_env.cpp
     ENV
       EMPTY_TEST=

--- a/include/rcpputils/time.hpp
+++ b/include/rcpputils/time.hpp
@@ -37,9 +37,9 @@ std::chrono::nanoseconds convert_to_nanoseconds(
   const std::chrono::duration<DurationRepT, DurationT> & time)
 {
   // Casting to a double representation might lose precision and allow the check below to succeed
-  // but the actual cast to nanoseconds fail. Using 1 DurationT worth of nanoseconds less than max
+  // but the actual cast to nanoseconds fail. Using 1 worth of nanoseconds less than max
   constexpr auto maximum_safe_cast_ns =
-    std::chrono::nanoseconds::max() - std::chrono::duration<DurationRepT, DurationT>(1);
+    std::chrono::nanoseconds::max() - std::chrono::nanoseconds(1);
   // If period is greater than nanoseconds::max(), the duration_cast to nanoseconds will overflow
   // a signed integer, which is undefined behavior. Checking whether any std::chrono::duration is
   // greater than nanoseconds::max() is a difficult general problem. This is a more conservative

--- a/include/rcpputils/time.hpp
+++ b/include/rcpputils/time.hpp
@@ -1,0 +1,62 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCPPUTILS__TIME_HPP_
+#define RCPPUTILS__TIME_HPP_
+
+#include <chrono>
+
+#include "rcutils/time.h"
+
+#include "rcpputils/visibility_control.hpp"
+
+namespace rcpputils
+{
+
+/// Convert to rcutils duration value.
+/*
+ * \param[in] time The time to be converted to rcutils duration.
+ * \return rcutils duration value
+ * \throws std::invalid_argument if time is bigger than std::chrono::nanoseconds::max().
+ */
+template<typename DurationRepT = int64_t, typename DurationT = std::milli>
+RCPPUTILS_PUBLIC
+rcutils_duration_value_t convert_to_rcutils_duration(
+  const std::chrono::duration<DurationRepT, DurationT> & time)
+{
+  // Casting to a double representation might lose precision and allow the check below to succeed
+  // but the actual cast to nanoseconds fail. Using 1 DurationT worth of nanoseconds less than max
+  constexpr auto maximum_safe_cast_ns =
+    std::chrono::nanoseconds::max() - std::chrono::duration<DurationRepT, DurationT>(1);
+  // If period is greater than nanoseconds::max(), the duration_cast to nanoseconds will overflow
+  // a signed integer, which is undefined behavior. Checking whether any std::chrono::duration is
+  // greater than nanoseconds::max() is a difficult general problem. This is a more conservative
+  // version of Howard Hinnant's (the <chrono> guy>) response here:
+  // https://stackoverflow.com/a/44637334/2089061
+  // However, this doesn't solve the issue for all possible duration types of period.
+  // Follow-up issue: https://github.com/ros2/rclcpp/issues/1177
+  constexpr auto ns_max_as_double =
+    std::chrono::duration_cast<std::chrono::duration<double, std::chrono::nanoseconds::period>>(
+    maximum_safe_cast_ns);
+  if (time > ns_max_as_double) {
+    throw std::invalid_argument{
+            "time must be less than std::chrono::nanoseconds::max()"};
+  }
+
+  return (std::chrono::duration_cast<std::chrono::nanoseconds>(time)).count();
+}
+
+}  // namespace rcpputils
+
+#endif  // RCPPUTILS__TIME_HPP_

--- a/include/rcpputils/time.hpp
+++ b/include/rcpputils/time.hpp
@@ -19,8 +19,6 @@
 
 #include "rcutils/time.h"
 
-#include "rcpputils/visibility_control.hpp"
-
 namespace rcpputils
 {
 
@@ -34,7 +32,6 @@ namespace rcpputils
  * \throws std::invalid_argument if time is bigger than std::chrono::nanoseconds::max().
  */
 template<typename DurationRepT = int64_t, typename DurationT = std::milli>
-RCPPUTILS_PUBLIC
 std::chrono::nanoseconds convert_to_nanoseconds(
   const std::chrono::duration<DurationRepT, DurationT> & time)
 {

--- a/include/rcpputils/time.hpp
+++ b/include/rcpputils/time.hpp
@@ -32,25 +32,13 @@ namespace rcpputils
  * \throws std::invalid_argument if time is bigger than std::chrono::nanoseconds::max() or less than
  * std::chrono::nanoseconds::min().
  */
-template<typename DurationRepT = int64_t, typename DurationT = std::milli>
+template<typename DurationRepT, typename DurationT>
 std::chrono::nanoseconds convert_to_nanoseconds(
   const std::chrono::duration<DurationRepT, DurationT> & time)
 {
-  // Casting to a double representation might lose precision and allow the check below to succeed
-  // but the actual cast to nanoseconds fail. Using 1 worth of nanoseconds less than max
-  constexpr auto maximum_safe_cast_ns =
-    std::chrono::nanoseconds::max() - std::chrono::nanoseconds(1);
-  // If period is greater than nanoseconds::max(), the duration_cast to nanoseconds will overflow
-  // a signed integer, which is undefined behavior. Checking whether any std::chrono::duration is
-  // greater than nanoseconds::max() is a difficult general problem. This is a more conservative
-  // version of Howard Hinnant's (the <chrono> guy>) response here:
-  // https://stackoverflow.com/a/44637334/2089061
-  // However, this doesn't solve the issue for all possible duration types of period.
-  // e.g std::chrono::hours(10000000) cannot be converted to nanoseconds.
-  // Follow-up issue: https://github.com/ros2/rclcpp/issues/1177
   constexpr auto ns_max_as_double =
     std::chrono::duration_cast<std::chrono::duration<double, std::chrono::nanoseconds::period>>(
-    maximum_safe_cast_ns);
+    std::chrono::nanoseconds::max());
   if (time > ns_max_as_double) {
     throw std::invalid_argument{
             "time must be less than std::chrono::nanoseconds::max()"};

--- a/include/rcpputils/time.hpp
+++ b/include/rcpputils/time.hpp
@@ -29,7 +29,8 @@ namespace rcpputils
  *
  * \param[in] time The time to be converted to std::chrono::nanoseconds.
  * \return std::chrono::nanoseconds.
- * \throws std::invalid_argument if time is bigger than std::chrono::nanoseconds::max().
+ * \throws std::invalid_argument if time is bigger than std::chrono::nanoseconds::max() or less than
+ * std::chrono::nanoseconds::min().
  */
 template<typename DurationRepT = int64_t, typename DurationT = std::milli>
 std::chrono::nanoseconds convert_to_nanoseconds(
@@ -52,6 +53,14 @@ std::chrono::nanoseconds convert_to_nanoseconds(
   if (time > ns_max_as_double) {
     throw std::invalid_argument{
             "time must be less than std::chrono::nanoseconds::max()"};
+  }
+
+  constexpr auto ns_min_as_double =
+    std::chrono::duration_cast<std::chrono::duration<double, std::chrono::nanoseconds::period>>(
+    std::chrono::nanoseconds::min());
+  if (time < ns_min_as_double) {
+    throw std::invalid_argument{
+            "time must be bigger than std::chrono::nanoseconds::min()"};
   }
 
   return std::chrono::duration_cast<std::chrono::nanoseconds>(time);

--- a/include/rcpputils/time.hpp
+++ b/include/rcpputils/time.hpp
@@ -46,6 +46,7 @@ std::chrono::nanoseconds convert_to_nanoseconds(
   // version of Howard Hinnant's (the <chrono> guy>) response here:
   // https://stackoverflow.com/a/44637334/2089061
   // However, this doesn't solve the issue for all possible duration types of period.
+  // e.g std::chrono::hours(10000000) cannot be converted to nanoseconds.
   // Follow-up issue: https://github.com/ros2/rclcpp/issues/1177
   constexpr auto ns_max_as_double =
     std::chrono::duration_cast<std::chrono::duration<double, std::chrono::nanoseconds::period>>(

--- a/include/rcpputils/time.hpp
+++ b/include/rcpputils/time.hpp
@@ -24,15 +24,18 @@
 namespace rcpputils
 {
 
-/// Convert to rcutils duration value.
-/*
- * \param[in] time The time to be converted to rcutils duration.
- * \return rcutils duration value
+/// Convert to std::chrono::nanoseconds.
+/**
+ * This function help to convert from std::chrono::duration to std::chrono::nanoseconds and throw
+ * exception if overflow occurs while coverting.
+ *
+ * \param[in] time The time to be converted to std::chrono::nanoseconds.
+ * \return std::chrono::nanoseconds.
  * \throws std::invalid_argument if time is bigger than std::chrono::nanoseconds::max().
  */
 template<typename DurationRepT = int64_t, typename DurationT = std::milli>
 RCPPUTILS_PUBLIC
-rcutils_duration_value_t convert_to_rcutils_duration(
+std::chrono::nanoseconds convert_to_nanoseconds(
   const std::chrono::duration<DurationRepT, DurationT> & time)
 {
   // Casting to a double representation might lose precision and allow the check below to succeed
@@ -54,7 +57,7 @@ rcutils_duration_value_t convert_to_rcutils_duration(
             "time must be less than std::chrono::nanoseconds::max()"};
   }
 
-  return (std::chrono::duration_cast<std::chrono::nanoseconds>(time)).count();
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(time);
 }
 
 }  // namespace rcpputils

--- a/test/test_time.cpp
+++ b/test/test_time.cpp
@@ -19,7 +19,8 @@
 TEST(test_time, test_convert_to_nanoseconds) {
   rcutils_duration_value_t expect_value = RCUTILS_S_TO_NS(5 * 60);  // 5 minutes
   rcutils_duration_value_t cast_val = 0;
-  EXPECT_NO_THROW(cast_val = rcpputils::convert_to_nanoseconds(std::chrono::minutes(5)).count());
+  EXPECT_NO_THROW(
+    cast_val = rcpputils::convert_to_nanoseconds(std::chrono::duration<double>(5 * 60)).count());
   EXPECT_EQ(cast_val, expect_value);
 
   EXPECT_THROW(

--- a/test/test_time.cpp
+++ b/test/test_time.cpp
@@ -16,13 +16,13 @@
 
 #include <rcpputils/time.hpp>
 
-TEST(test_time, test_convert_to_rcutils_duration) {
+TEST(test_time, test_convert_to_nanoseconds) {
   rcutils_duration_value_t expect_value = RCUTILS_S_TO_NS(5 * 60);  // 5 minutes
   rcutils_duration_value_t cast_val;
-  EXPECT_NO_THROW(cast_val = rcpputils::convert_to_rcutils_duration(std::chrono::minutes(5)));
+  EXPECT_NO_THROW(cast_val = rcpputils::convert_to_nanoseconds(std::chrono::minutes(5)).count());
   EXPECT_EQ(cast_val, expect_value);
 
   EXPECT_THROW(
-    rcpputils::convert_to_rcutils_duration(std::chrono::hours(10000000)),
+    rcpputils::convert_to_nanoseconds(std::chrono::hours(10000000)),
     std::invalid_argument);
 }

--- a/test/test_time.cpp
+++ b/test/test_time.cpp
@@ -1,0 +1,28 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <rcpputils/time.hpp>
+
+TEST(test_time, test_convert_to_rcutils_duration) {
+  rcutils_duration_value_t expect_value = RCUTILS_S_TO_NS(5 * 60);  // 5 minutes
+  rcutils_duration_value_t cast_val;
+  EXPECT_NO_THROW(cast_val = rcpputils::convert_to_rcutils_duration(std::chrono::minutes(5)));
+  EXPECT_EQ(cast_val, expect_value);
+
+  EXPECT_THROW(
+    rcpputils::convert_to_rcutils_duration(std::chrono::hours(10000000)),
+    std::invalid_argument);
+}

--- a/test/test_time.cpp
+++ b/test/test_time.cpp
@@ -18,7 +18,7 @@
 
 TEST(test_time, test_convert_to_nanoseconds) {
   rcutils_duration_value_t expect_value = RCUTILS_S_TO_NS(5 * 60);  // 5 minutes
-  rcutils_duration_value_t cast_val;
+  rcutils_duration_value_t cast_val = 0;
   EXPECT_NO_THROW(cast_val = rcpputils::convert_to_nanoseconds(std::chrono::minutes(5)).count());
   EXPECT_EQ(cast_val, expect_value);
 


### PR DESCRIPTION
Add a new interface `rcpputils::rcutils_duration_cast`.   

About this new interface, it is mentioned at ros2/rclcpp#1662 (https://github.com/ros2/rclcpp/pull/1662#discussion_r707634117)