### PR TITLE
Add missing cstddef include

### DIFF
--- a/include/rcppmath/rolling_mean_accumulator.hpp
+++ b/include/rcppmath/rolling_mean_accumulator.hpp
@@ -21,6 +21,7 @@
 
 #include <cassert>
 #include <vector>
+#include <cstddef>
 
 namespace rcppmath
 {

--- a/include/rcppmath/rolling_mean_accumulator.hpp
+++ b/include/rcppmath/rolling_mean_accumulator.hpp
@@ -20,8 +20,8 @@
 #define RCPPMATH__ROLLING_MEAN_ACCUMULATOR_HPP_
 
 #include <cassert>
-#include <vector>
 #include <cstddef>
+#include <vector>
 
 namespace rcppmath
 {


### PR DESCRIPTION
This PR adds a missing header to fix compilation on GCC 11. I tested this locally on `gcc (GCC) 11.2.1 20210728 (Red Hat 11.2.1-1)`.

Fixes #146.
