### PR TITLE
[path] Declare the default assignment operator

### DIFF
--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -94,6 +94,13 @@ public:
   RCPPUTILS_PUBLIC path(const path & p) = default;
 
   /**
+   * \brief Copy assignment operator.
+   *
+   * \return Reference to the copied path.
+   */
+  RCPPUTILS_PUBLIC path & operator=(const path &) = default;
+
+  /**
    * \brief Get the path delimited using this system's path separator.
    *
    * \return The path as a string


### PR DESCRIPTION
Satisfies `-Wdeprecated-copy` in Clang 13.

Closes #155.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>
