### PR TITLE
Support ROS2 Hololens 2

### DIFF
--- a/src/find_library.cpp
+++ b/src/find_library.cpp
@@ -62,7 +62,7 @@ std::string find_library_path(const std::string & library_name)
   std::string search_path = get_env_var(kPathVar);
   std::vector<std::string> search_paths = rcpputils::split(search_path, kPathSeparator);
 
-  #ifdef _WIN32 && WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+  #if defined(_WIN32) && WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
   uint32_t length = GetDllDirectoryA(0, NULL);
   if (length > 0)
   {


### PR DESCRIPTION
Hololens 2 uses a version of Windows which specifically prohibits certain APIs from being used. In this repository, prohibited APIs are used. On Universal Windows Platform (UWP), filesystem enumeration is not required, so simply removed. UWP is Unicode only, so conversion is required. Additionally, DLL path resolution was not considering alternative load paths, which prevented loading from within UWP Containers.

These changes are in the WIN32 block, using the family partition, so do not affect other build types.