### PR TITLE
Fix possible race condition in create_directories()

### DIFF
--- a/src/filesystem_helper.cpp
+++ b/src/filesystem_helper.cpp
@@ -371,12 +371,13 @@ bool create_directories(const path & p)
     } else {
       p_built = *it;
     }
-    if (!p_built.exists()) {
 #ifdef _WIN32
-      status = _mkdir(p_built.string().c_str());
+    status = _mkdir(p_built.string().c_str());
 #else
-      status = mkdir(p_built.string().c_str(), S_IRWXU | S_IRWXG | S_IRWXO);
+    status = mkdir(p_built.string().c_str(), S_IRWXU | S_IRWXG | S_IRWXO);
 #endif
+    if (status == -1 && errno == EEXIST) {
+      status = 0;
     }
   }
   return status == 0 && p_built.is_directory();

--- a/src/filesystem_helper.cpp
+++ b/src/filesystem_helper.cpp
@@ -371,13 +371,15 @@ bool create_directories(const path & p)
     } else {
       p_built = *it;
     }
+    if (!p_built.exists()) {
 #ifdef _WIN32
-    status = _mkdir(p_built.string().c_str());
+      status = _mkdir(p_built.string().c_str());
 #else
-    status = mkdir(p_built.string().c_str(), S_IRWXU | S_IRWXG | S_IRWXO);
+      status = mkdir(p_built.string().c_str(), S_IRWXU | S_IRWXG | S_IRWXO);
 #endif
-    if (status == -1 && errno == EEXIST) {
-      status = 0;
+      if (status == -1 && errno == EEXIST) {
+        status = 0;
+      }
     }
   }
   return status == 0 && p_built.is_directory();


### PR DESCRIPTION
Use only `mkdir()` function instead of using the non-atomic sequence `access() + mkdir()`.

Motivation: After two processes get `False` from `p_built.exists()`, they both call `mkdir()` and one of them gets `status == -1` and `errno == EEXIST`
