### PR TITLE
require C++17 and deprecate the rcppmath namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,9 @@ find_package(rcutils REQUIRED)
 if(NOT CMAKE_C_STANDARD)
   set(CMAKE_C_STANDARD 11)
 endif()
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,6 +1,7 @@
 # rcpputils Features
 
-This package includes convenience functions for cross-platform c++ functionality and for mathematical utilties. These functionalities are siloed into the `rcpputils` and the `rcppmath` namespaces respectively:
+This package includes convenience functions for cross-platform c++ functionality and for mathematical utilties.
+These functionalities are siloed into the `rcpputils` namespace:
 * [`rcpputils` - General convenience functions](#rcpputils-general-convenience-functions)
   * [Assertion functions](#assertion-functions)
   * [Clang thread safety annotation macros](#clang-thread-safety-annotation-macros)
@@ -14,8 +15,6 @@ This package includes convenience functions for cross-platform c++ functionality
   * [Process helpers](#process-helpers)
   * [Environment helpers](#environment-helpers)
   * [Scope guard support](#scope-guard-support)
-* [`rcppmath` - Mathematical utilties](#rcppmath-mathematical-utilities)
-  * [Clamping functionality](#clamping-functionality)
   * [Rolling mean accumulator](#rolling-mean-accumulator)
 
 ## `rcpputils` - General convenience functions {#rcpputils-general-convenience-functions}
@@ -142,15 +141,7 @@ release_resource(resource);
 cleanup_resource_handle.cancel();
 ```
 
-## `rcppmath` - Mathematical utilities {#rcppmath-mathematical-utilities}
-### Clamping functionality {#clamping-functionality}
-`rcppmath/clamp.hpp` provides functionality to perform clamping - which restricts a value between two bounds.
-The `rcppmath::clamp()` function is overloaded as follows:
-
-* `rcppmath::clamp(const T &, const T &, const T &)`: Takes a value to clamp, and the lower and upper boundaries to clamp against.
-* `rcppmath::clamp(const T &, const T &, const T &, Compare)`: In addition to the previous signature, accepts a comparison object that returns `true` if its first argument is less than the second.
-
 ### Rolling mean accumulator {#rolling-mean-accumulator}
-The `rcppmath/rolling_mean_accumulator.hpp` facilitates computing the rolling mean of a window of accumulated items.
-The `rcppmath::RollingMeanAccumulator` can be constructed with an unsigned integral `rolling_window_size` value.
-Values can be accumulated and the rolling mean can be obtained through the `rcppmath::RollingMeanAccumulator::accumulate(T)` method and the `rcppmath::RollingMeanAccumulator::getRollingMean()` methods respectively.
+The `rcpputils/rolling_mean_accumulator.hpp` facilitates computing the rolling mean of a window of accumulated items.
+The `rcpputils::RollingMeanAccumulator` can be constructed with an unsigned integral `rolling_window_size` value.
+Values can be accumulated and the rolling mean can be obtained through the `rcpputils::RollingMeanAccumulator::accumulate(T)` method and the `rcpputils::RollingMeanAccumulator::getRollingMean()` methods respectively.

--- a/include/rcppmath/clamp.hpp
+++ b/include/rcppmath/clamp.hpp
@@ -21,11 +21,6 @@
 
 #include <cassert>
 
-
-#ifndef RCPPMATH__CLAMP_HPP_WARNING_DISABLED
-# warning "the rcppmath namespace is deprecated, include <algorithm> and use std::clamp instead"
-#endif
-
 namespace rcppmath
 {
 /**
@@ -42,6 +37,7 @@ namespace rcppmath
  *  a dangling reference if that parameter is returned.
  */
 template<class T>
+[[deprecated("use std::clamp instead, introduced in C++17")]]
 constexpr const T & clamp(const T & v, const T & lo, const T & hi)
 {
   assert(!(hi < lo) );
@@ -63,6 +59,7 @@ constexpr const T & clamp(const T & v, const T & lo, const T & hi)
  * \sa rcppmath::clamp(const T&, const T&, const T&)
  */
 template<class T, class Compare>
+[[deprecated("use std::clamp instead, introduced in C++17")]]
 constexpr const T & clamp(const T & v, const T & lo, const T & hi, Compare comp)
 {
   assert(!comp(hi, lo) );

--- a/include/rcppmath/clamp.hpp
+++ b/include/rcppmath/clamp.hpp
@@ -21,6 +21,11 @@
 
 #include <cassert>
 
+
+#ifndef RCPPMATH__CLAMP_HPP_WARNING_DISABLED
+# warning "the rcppmath namespace is deprecated, include <algorithm> and use std::clamp instead"
+#endif
+
 namespace rcppmath
 {
 /**

--- a/include/rcppmath/rolling_mean_accumulator.hpp
+++ b/include/rcppmath/rolling_mean_accumulator.hpp
@@ -12,73 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/*
- * Author: Víctor López
- */
-
 #ifndef RCPPMATH__ROLLING_MEAN_ACCUMULATOR_HPP_
 #define RCPPMATH__ROLLING_MEAN_ACCUMULATOR_HPP_
 
-#include <cassert>
-#include <cstddef>
-#include <vector>
+#include "rcpputils/rolling_mean_accumulator.hpp"
+
+#warning \
+  "the rcppmath namespace is deprecated, include rcpputils/rolling_mean_accumulator.hpp instead"
 
 namespace rcppmath
 {
 
-/**
- * \brief Computes the mean of the last accumulated elements.
- *
- * This is a simplified version of boost's rolling mean accumulator,
- * written to avoid dragging in boost dependencies.
- */
 template<typename T>
-class RollingMeanAccumulator
-{
-public:
-  /**
-   * Constructs the rolling mean accumulator with a specified window size.
-   *
-   * \param[in] rolling_window_size The unsigned integral length of the accumulator's window length.
-   */
-  explicit RollingMeanAccumulator(size_t rolling_window_size)
-  : buffer_(rolling_window_size, 0.0), next_insert_(0),
-    sum_(0.0), buffer_filled_(false)
-  {
-  }
+using RollingMeanAccumulator [[deprecated("use rcpputils::RollingMeanAccumulator instead")]] =
+  rcpputils::RollingMeanAccumulator<T>;
 
-  /**
-   * Collects the provided value in the accumulator's buffer.
-   *
-   * \param[in] val The value to accumulate.
-   */
-  void accumulate(T val)
-  {
-    sum_ -= buffer_[next_insert_];
-    sum_ += val;
-    buffer_[next_insert_] = val;
-    next_insert_++;
-    buffer_filled_ |= next_insert_ >= buffer_.size();
-    next_insert_ = next_insert_ % buffer_.size();
-  }
-
-  /**
-   * Calculates the rolling mean accumulated insofar.
-   *
-   * \return Rolling mean of the accumulated values.
-   */
-  T getRollingMean() const
-  {
-    size_t valid_data_count = buffer_filled_ * buffer_.size() + !buffer_filled_ * next_insert_;
-    assert(valid_data_count > 0);
-    return sum_ / valid_data_count;
-  }
-
-private:
-  std::vector<T> buffer_;
-  size_t next_insert_;
-  T sum_;
-  bool buffer_filled_;
-};
 }  // namespace rcppmath
+
 #endif  // RCPPMATH__ROLLING_MEAN_ACCUMULATOR_HPP_

--- a/include/rcpputils/rolling_mean_accumulator.hpp
+++ b/include/rcpputils/rolling_mean_accumulator.hpp
@@ -1,0 +1,88 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Author: Víctor López
+ */
+
+#ifndef RCPPUTILS__ROLLING_MEAN_ACCUMULATOR_HPP_
+#define RCPPUTILS__ROLLING_MEAN_ACCUMULATOR_HPP_
+
+#include <cassert>
+#include <cstddef>
+#include <vector>
+
+namespace rcpputils
+{
+
+/// Computes the mean of the last accumulated elements.
+/**
+ * This is a simplified version of boost's rolling mean accumulator,
+ * written to avoid dragging in boost dependencies.
+ */
+template<typename T>
+class RollingMeanAccumulator
+{
+public:
+  /**
+   * Constructs the rolling mean accumulator with a specified window size.
+   *
+   * \param[in] rolling_window_size The unsigned integral length of the accumulator's window length.
+   */
+  explicit RollingMeanAccumulator(size_t rolling_window_size)
+  : buffer_(rolling_window_size, 0.0),
+    next_insert_(0),
+    sum_(0.0),
+    buffer_filled_(false)
+  {}
+
+  /**
+   * Collects the provided value in the accumulator's buffer.
+   *
+   * \param[in] val The value to accumulate.
+   */
+  void
+  accumulate(T val)
+  {
+    sum_ -= buffer_[next_insert_];
+    sum_ += val;
+    buffer_[next_insert_] = val;
+    next_insert_++;
+    buffer_filled_ |= next_insert_ >= buffer_.size();
+    next_insert_ = next_insert_ % buffer_.size();
+  }
+
+  /**
+   * Calculates the rolling mean accumulated insofar.
+   *
+   * \return Rolling mean of the accumulated values.
+   */
+  T
+  getRollingMean() const
+  {
+    size_t valid_data_count = buffer_filled_ * buffer_.size() + !buffer_filled_ * next_insert_;
+    assert(valid_data_count > 0);
+    return sum_ / valid_data_count;
+  }
+
+private:
+  std::vector<T> buffer_;
+  size_t next_insert_;
+  T sum_;
+  bool buffer_filled_;
+};
+
+}  // namespace rcpputils
+
+#endif  // RCPPUTILS__ROLLING_MEAN_ACCUMULATOR_HPP_

--- a/test/test_accumulator.cpp
+++ b/test/test_accumulator.cpp
@@ -25,12 +25,12 @@
 
 #include "gtest/gtest.h"
 
-#include "rcppmath/rolling_mean_accumulator.hpp"
+#include "rcpputils/rolling_mean_accumulator.hpp"
 
 TEST(TestAccumulator, test_accumulator)
 {
   constexpr double THRESHOLD = 1e-12;
-  rcppmath::RollingMeanAccumulator<double> accum(4);
+  rcpputils::RollingMeanAccumulator<double> accum(4);
 
   accum.accumulate(1.);
   EXPECT_NEAR(1., accum.getRollingMean(), THRESHOLD);
@@ -55,7 +55,7 @@ TEST(TestAccumulator, test_accumulator)
 TEST(TestAccumulator, spam_accumulator)
 {
   constexpr double THRESHOLD = 1e-12;
-  rcppmath::RollingMeanAccumulator<double> accum(10);
+  rcpputils::RollingMeanAccumulator<double> accum(10);
   for (int i = 0; i < 10000; ++i) {
     accum.accumulate(M_PI);
     EXPECT_NEAR(M_PI, accum.getRollingMean(), THRESHOLD);

--- a/test/test_clamp.cpp
+++ b/test/test_clamp.cpp
@@ -15,9 +15,7 @@
 #include <gtest/gtest.h>
 #include <limits>
 
-#define RCPPMATH__CLAMP_HPP_WARNING_DISABLED 1
 #include "rcppmath/clamp.hpp"
-#undef RCPPMATH__CLAMP_HPP_WARNING_DISABLED
 
 #ifdef _MSC_VER
 #pragma warning(push)

--- a/test/test_clamp.cpp
+++ b/test/test_clamp.cpp
@@ -15,7 +15,17 @@
 #include <gtest/gtest.h>
 #include <limits>
 
+#define RCPPMATH__CLAMP_HPP_WARNING_DISABLED 1
 #include "rcppmath/clamp.hpp"
+#undef RCPPMATH__CLAMP_HPP_WARNING_DISABLED
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#else
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 TEST(test_clamp, test_basic) {
   EXPECT_EQ(rcppmath::clamp(1, 2, 5), 2);
@@ -50,3 +60,9 @@ TEST(test_clamp, test_limits) {
       std::numeric_limits<double>::quiet_NaN(), 0.0, 1.0),
     std::numeric_limits<double>::quiet_NaN());
 }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#else
+#pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
As the title says, now that we can use c++17 in rolling we can do away with the `clamp.hpp` header because it's just implementing `std::clamp` which was added in c++17. Also as discussed in https://github.com/ros2/rcpputils/pull/85#issuecomment-754134335, removing the `rcppmath` namespace as it doesn't follow our conventions that packages should only put headers and symbols in their own namespace unless at all possible.