### PR TITLE
Add missing header for strlen

### DIFF
--- a/include/rcpputils/join.hpp
+++ b/include/rcpputils/join.hpp
@@ -20,6 +20,7 @@
 #define RCPPUTILS__JOIN_HPP_
 
 #include <algorithm>
+#include <cstring>
 #include <iterator>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
rcpputils/join.hpp is missing a header for strlen which has to be added manually when you include rcpputils/join.hpp. You shouldn't have to add this header manually.