### PR TITLE
issue-167

### DIFF
--- a/test/dummy_shared_library/dummy_shared_library.c
+++ b/test/dummy_shared_library/dummy_shared_library.c
@@ -14,7 +14,7 @@
 
 #include "./dummy_shared_library.h" // NOLINT
 
-void print_name()
+void print_name(void)
 {
   printf("print_name\n");
 }

--- a/test/dummy_shared_library/dummy_shared_library.h
+++ b/test/dummy_shared_library/dummy_shared_library.h
@@ -28,6 +28,6 @@
 #include <stdio.h>
 
 DUMMY_SHARED_LIBRARY_PUBLIC
-void print_name();
+void print_name(void);
 
 #endif  // DUMMY_SHARED_LIBRARY__DUMMY_SHARED_LIBRARY_H_


### PR DESCRIPTION
Explicitly added void to change the function to a function with prototype. See https://discourse.llvm.org/t/rfc-enabling-wstrict-prototypes-by-default-in-c/60521 See https://reviews.llvm.org/D122895
Fixes: https://github.com/ros2/rcpputils/issues/167

Signed-off-by: Sebastian Freitag <sebastian.freitag@pylot.tech>