### PR TITLE
Add unique_lock implementation with clang thread safety annotations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,9 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_accumulator test/test_accumulator.cpp)
   target_link_libraries(test_accumulator ${PROJECT_NAME})
+
+  ament_add_gtest(test_unique_lock test/test_unique_lock.cpp)
+  target_link_libraries(test_unique_lock ${PROJECT_NAME})
 endif()
 
 ament_package()

--- a/include/rcpputils/unique_lock.hpp
+++ b/include/rcpputils/unique_lock.hpp
@@ -1,0 +1,36 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rcpputils/thread_safety_annotations.hpp"
+
+namespace rcpputils
+{
+
+/**
+ * @brief Trivial std::unique_lock wrapper providing constructor that allows Clang's
+ * Thread Safety Analysis.
+ * The libc++ std::unique_lock does not have these annotations.
+ */
+template<typename MutexT>
+class RCPPUTILS_TSA_SCOPED_CAPABILITY unique_lock : public std::unique_lock<MutexT>
+{
+public:
+  explicit unique_lock(std::mutex & mu) RCPPUTILS_TSA_ACQUIRE(mu)
+  : std::unique_lock<MutexT>(mu)
+  {}
+
+  ~TSAUniqueLock() RCPPUTILS_TSA_RELEASE() {}
+};
+
+}  // namespace rcpputils

--- a/include/rcpputils/unique_lock.hpp
+++ b/include/rcpputils/unique_lock.hpp
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef RCPPUTILS__UNIQUE_LOCK_HPP_
+#define RCPPUTILS__UNIQUE_LOCK_HPP_
+
+#include <mutex>
+
 #include "rcpputils/thread_safety_annotations.hpp"
 
 namespace rcpputils
@@ -34,3 +39,5 @@ public:
 };
 
 }  // namespace rcpputils
+
+#endif  // RCPPUTILS__UNIQUE_LOCK_HPP_

--- a/include/rcpputils/unique_lock.hpp
+++ b/include/rcpputils/unique_lock.hpp
@@ -31,7 +31,7 @@ template<typename MutexT>
 class RCPPUTILS_TSA_SCOPED_CAPABILITY unique_lock : public std::unique_lock<MutexT>
 {
 public:
-  explicit unique_lock(std::mutex & mu) RCPPUTILS_TSA_ACQUIRE(mu)
+  explicit unique_lock(MutexT & mu) RCPPUTILS_TSA_ACQUIRE(mu)
   : std::unique_lock<MutexT>(mu)
   {}
 

--- a/include/rcpputils/unique_lock.hpp
+++ b/include/rcpputils/unique_lock.hpp
@@ -35,7 +35,7 @@ public:
   : std::unique_lock<MutexT>(mu)
   {}
 
-  ~TSAUniqueLock() RCPPUTILS_TSA_RELEASE() {}
+  ~unique_lock() RCPPUTILS_TSA_RELEASE() {}
 };
 
 }  // namespace rcpputils

--- a/test/test_unique_lock.cpp
+++ b/test/test_unique_lock.cpp
@@ -1,0 +1,26 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <rcpputils/unique_lock.hpp>
+
+TEST(test_time, test_compile_multiple_mutex_types) {
+  // Very simple check that this compiles with different mutex types
+  std::mutex regular_mutex;
+  rcpputils::unique_lock<std::mutex> lock1(regular_mutex);
+
+  std::recursive_mutex recursive_mutex;
+  rcpputils::unique_lock<std::recursive_mutex> lock2(recursive_mutex);
+}


### PR DESCRIPTION
Can be used to replace rosbag2 implementation https://github.com/ros2/rosbag2/blob/rolling/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp#L31
and false positive errors in RMW builds like https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/1628/clang/new/source.cf52365c-c9dc-4c3e-8639-55ffa17e1b64/#115