### PR TITLE
Add a missing header due to missing PATH_MAX variable

### DIFF
--- a/src/filesystem_helper.cpp
+++ b/src/filesystem_helper.cpp
@@ -41,8 +41,8 @@
 #include <sys/stat.h>
 
 #include <algorithm>
-#include <cstring>
 #include <climits>
+#include <cstring>
 #include <string>
 #include <system_error>
 #include <vector>

--- a/src/filesystem_helper.cpp
+++ b/src/filesystem_helper.cpp
@@ -42,6 +42,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <climits>
 #include <string>
 #include <system_error>
 #include <vector>


### PR DESCRIPTION
The `xtensa-esp32` compiler does not recognize the PATH_MAX variable because the header `climits` is missing.
![missing_header](https://github.com/ros2/rcpputils/assets/108528301/3ebcf8e7-0fb8-4fd6-8bc0-1f9dd723deee)
