### PR TITLE
Generate version header with ament_generate_version_header function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,3 +181,4 @@ install(
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
+ament_generate_version_header(${PROJECT_NAME})

--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,7 @@
   <author email="michael.jeronimo@openrobotics.org">Michael Jeronimo</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_gen_version_h</buildtool_depend>
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <depend>rcutils</depend>


### PR DESCRIPTION
Calls the ament_cmake_gen_version_header function to generate and a header file containing rcpputils version information.

Provides compile-time version information for rcpputils!

If this can be merged and also backported to Iron and Humble. It would be really helpful

Thank you