### PR TITLE
Use std::filesystem in create_temp_directory and temp_directory_path

### DIFF
--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -40,6 +40,7 @@
 #define RCPPUTILS__FILESYSTEM_HELPER_HPP_
 
 #include <cstdint>
+#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -269,7 +270,7 @@ RCPPUTILS_PUBLIC bool exists(const path & path_to_check);
  *
  * \return A path to a directory for storing temporary files and directories.
  */
-RCPPUTILS_PUBLIC path temp_directory_path();
+RCPPUTILS_PUBLIC std::filesystem::path temp_directory_path();
 
 /**
  * \brief Construct a uniquely named temporary directory, in "parent", with format base_nameXXXXXX
@@ -284,9 +285,9 @@ RCPPUTILS_PUBLIC path temp_directory_path();
  *
  * \throws std::system_error If any OS APIs do not succeed.
  */
-RCPPUTILS_PUBLIC path create_temp_directory(
+RCPPUTILS_PUBLIC std::filesystem::path create_temp_directory(
   const std::string & base_name,
-  const path & parent_path = temp_directory_path());
+  const std::filesystem::path & parent_path = temp_directory_path());
 
 /**
  * \brief Return current working directory.

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -261,6 +261,23 @@ RCPPUTILS_PUBLIC uint64_t file_size(const path & p);
 RCPPUTILS_PUBLIC bool exists(const path & path_to_check);
 
 /**
+ * \brief Construct a uniquely named temporary directory, in "parent", with format base_nameXXXXXX
+ *
+ * The output, if successful, is guaranteed to be a newly-created directory.
+ * The underlying implementation keeps generating paths until one that does not exist is found.
+ * This guarantees that there will be no existing files in the returned directory.
+ *
+ * \param[in] base_name User-specified portion of the created directory
+ * \param[in] parent_path The parent path of the directory that will be created
+ * \return A path to a newly-created directory with base_name and a 6-character unique suffix
+ *
+ * \throws std::system_error If any OS APIs do not succeed.
+ */
+RCPPUTILS_PUBLIC std::filesystem::path create_temp_directory(
+  const std::string & base_name,
+  const std::filesystem::path & parent_path = std::filesystem::temp_directory_path());
+
+/**
  * \brief Return current working directory.
  *
  * \return The current working directory.

--- a/include/rcpputils/filesystem_helper.hpp
+++ b/include/rcpputils/filesystem_helper.hpp
@@ -260,35 +260,6 @@ RCPPUTILS_PUBLIC uint64_t file_size(const path & p);
  */
 RCPPUTILS_PUBLIC bool exists(const path & path_to_check);
 
-
-/**
- * \brief Get a path to a location in the temporary directory, if it's available.
- *
- * This does not create any directories.
- * On Windows, this uses "GetTempPathA"
- * On non-Windows, this prefers the environment variable TMPDIR, falling back to /tmp
- *
- * \return A path to a directory for storing temporary files and directories.
- */
-RCPPUTILS_PUBLIC std::filesystem::path temp_directory_path();
-
-/**
- * \brief Construct a uniquely named temporary directory, in "parent", with format base_nameXXXXXX
- *
- * The output, if successful, is guaranteed to be a newly-created directory.
- * The underlying implementation keeps generating paths until one that does not exist is found.
- * This guarantees that there will be no existing files in the returned directory.
- *
- * \param[in] base_name User-specified portion of the created directory
- * \param[in] parent_path The parent path of the directory that will be created
- * \return A path to a newly-created directory with base_name and a 6-character unique suffix
- *
- * \throws std::system_error If any OS APIs do not succeed.
- */
-RCPPUTILS_PUBLIC std::filesystem::path create_temp_directory(
-  const std::string & base_name,
-  const std::filesystem::path & parent_path = temp_directory_path());
-
 /**
  * \brief Return current working directory.
  *

--- a/src/filesystem_helper.cpp
+++ b/src/filesystem_helper.cpp
@@ -284,7 +284,7 @@ bool exists(const path & path_to_check)
   return path_to_check.exists();
 }
 
-path temp_directory_path()
+std::filesystem::path temp_directory_path()
 {
 #ifdef _WIN32
 #ifdef UNICODE
@@ -304,16 +304,18 @@ path temp_directory_path()
     temp_path = "/tmp";
   }
 #endif
-  return path(temp_path);
+  return std::filesystem::path(temp_path);
 }
 
-path create_temp_directory(const std::string & base_name, const path & parent_path)
+std::filesystem::path create_temp_directory(
+  const std::string & base_name,
+  const std::filesystem::path & parent_path)
 {
   const auto template_path = base_name + "XXXXXX";
   std::string full_template_str = (parent_path / template_path).string();
-  if (!create_directories(parent_path)) {
-    std::error_code ec{errno, std::system_category()};
-    errno = 0;
+  std::error_code ec;
+  std::filesystem::create_directories(parent_path, ec);
+  if (ec) {
     throw std::system_error(ec, "could not create the parent directory");
   }
 
@@ -335,7 +337,7 @@ path create_temp_directory(const std::string & base_name, const path & parent_pa
     errno = 0;
     throw std::system_error(ec, "could not format or create the temp directory");
   }
-  const path final_path{dir_name};
+  const std::filesystem::path final_path{dir_name};
 #endif
 
   return final_path;

--- a/src/filesystem_helper.cpp
+++ b/src/filesystem_helper.cpp
@@ -284,6 +284,42 @@ bool exists(const path & path_to_check)
   return path_to_check.exists();
 }
 
+std::filesystem::path create_temp_directory(
+  const std::string & base_name,
+  const std::filesystem::path & parent_path)
+{
+  const auto template_path = base_name + "XXXXXX";
+  std::string full_template_str = (parent_path / template_path).string();
+  std::error_code ec;
+  std::filesystem::create_directories(parent_path, ec);
+  if (ec) {
+    throw std::system_error(ec, "could not create the parent directory");
+  }
+
+#ifdef _WIN32
+  errno_t errcode = _mktemp_s(&full_template_str[0], full_template_str.size() + 1);
+  if (errcode) {
+    std::error_code ec(static_cast<int>(errcode), std::system_category());
+    throw std::system_error(ec, "could not format the temp directory name template");
+  }
+  const path final_path{full_template_str};
+  if (!create_directories(final_path)) {
+    std::error_code ec(static_cast<int>(GetLastError()), std::system_category());
+    throw std::system_error(ec, "could not create the temp directory");
+  }
+#else
+  const char * dir_name = mkdtemp(&full_template_str[0]);
+  if (dir_name == nullptr) {
+    std::error_code ec{errno, std::system_category()};
+    errno = 0;
+    throw std::system_error(ec, "could not format or create the temp directory");
+  }
+  const std::filesystem::path final_path{dir_name};
+#endif
+
+  return final_path;
+}
+
 path current_path()
 {
 #ifdef _WIN32

--- a/src/filesystem_helper.cpp
+++ b/src/filesystem_helper.cpp
@@ -284,65 +284,6 @@ bool exists(const path & path_to_check)
   return path_to_check.exists();
 }
 
-std::filesystem::path temp_directory_path()
-{
-#ifdef _WIN32
-#ifdef UNICODE
-#error "rcpputils::fs does not support Unicode paths"
-#endif
-  TCHAR temp_path[MAX_PATH];
-  DWORD size = GetTempPathA(MAX_PATH, temp_path);
-  if (size > MAX_PATH || size == 0) {
-    std::error_code ec(static_cast<int>(GetLastError()), std::system_category());
-    throw std::system_error(ec, "cannot get temporary directory path");
-  }
-  temp_path[size] = '\0';
-#else
-  const char * temp_path = NULL;
-  const char * ret_str = rcutils_get_env("TMPDIR", &temp_path);
-  if (NULL != ret_str || *temp_path == '\0') {
-    temp_path = "/tmp";
-  }
-#endif
-  return std::filesystem::path(temp_path);
-}
-
-std::filesystem::path create_temp_directory(
-  const std::string & base_name,
-  const std::filesystem::path & parent_path)
-{
-  const auto template_path = base_name + "XXXXXX";
-  std::string full_template_str = (parent_path / template_path).string();
-  std::error_code ec;
-  std::filesystem::create_directories(parent_path, ec);
-  if (ec) {
-    throw std::system_error(ec, "could not create the parent directory");
-  }
-
-#ifdef _WIN32
-  errno_t errcode = _mktemp_s(&full_template_str[0], full_template_str.size() + 1);
-  if (errcode) {
-    std::error_code ec(static_cast<int>(errcode), std::system_category());
-    throw std::system_error(ec, "could not format the temp directory name template");
-  }
-  const path final_path{full_template_str};
-  if (!create_directories(final_path)) {
-    std::error_code ec(static_cast<int>(GetLastError()), std::system_category());
-    throw std::system_error(ec, "could not create the temp directory");
-  }
-#else
-  const char * dir_name = mkdtemp(&full_template_str[0]);
-  if (dir_name == nullptr) {
-    std::error_code ec{errno, std::system_category()};
-    errno = 0;
-    throw std::system_error(ec, "could not format or create the temp directory");
-  }
-  const std::filesystem::path final_path{dir_name};
-#endif
-
-  return final_path;
-}
-
 path current_path()
 {
 #ifdef _WIN32

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -447,6 +447,82 @@ TEST(TestFilesystemHelper, stream_operator)
   ASSERT_EQ(s.str(), "barfoo");
 }
 
+TEST(TestFilesystemHelper, create_temp_directory)
+{
+  // basic usage
+  {
+    const std::string basename = "test_base_name";
+
+    const auto tmpdir1_std = rcpputils::fs::create_temp_directory(basename);
+    rcpputils::fs::path tmpdir1(tmpdir1_std.c_str());
+
+    EXPECT_TRUE(tmpdir1.exists());
+    EXPECT_TRUE(tmpdir1.is_directory());
+
+    auto tmp_file = tmpdir1 / "test_file.txt";
+    {
+      std::ofstream output_buffer{tmp_file.string()};
+      output_buffer << "test";
+    }
+    EXPECT_TRUE(rcpputils::fs::exists(tmp_file));
+    EXPECT_TRUE(rcpputils::fs::is_regular_file(tmp_file));
+
+    const auto tmpdir2_std = rcpputils::fs::create_temp_directory(basename);
+    rcpputils::fs::path tmpdir2(tmpdir2_std.c_str());
+    EXPECT_TRUE(tmpdir2.exists());
+    EXPECT_TRUE(tmpdir2.is_directory());
+
+    EXPECT_NE(tmpdir1.string(), tmpdir2.string());
+
+    EXPECT_TRUE(rcpputils::fs::remove_all(tmpdir1));
+    EXPECT_TRUE(rcpputils::fs::remove_all(tmpdir2));
+  }
+
+  // bad names
+  {
+    if (is_win32) {
+      EXPECT_THROW(rcpputils::fs::create_temp_directory("illegalchar?"), std::system_error);
+    } else {
+      EXPECT_THROW(rcpputils::fs::create_temp_directory("base/name"), std::system_error);
+    }
+  }
+
+  // newly created paths
+  {
+    const auto new_relative = rcpputils::fs::current_path() / "child1" / "child2";
+    const auto tmpdir_std = rcpputils::fs::create_temp_directory(
+      "base_name",
+      std::filesystem::path(new_relative.string()));
+    rcpputils::fs::path tmpdir(tmpdir_std.c_str());
+
+    EXPECT_TRUE(tmpdir.exists());
+    EXPECT_TRUE(tmpdir.is_directory());
+    EXPECT_TRUE(rcpputils::fs::remove_all(tmpdir));
+  }
+
+  // edge case inputs
+  {
+    // Provided no base name we should still get a path with the 6 unique template chars
+    const auto tmpdir_emptybase = rcpputils::fs::create_temp_directory("");
+    EXPECT_EQ(tmpdir_emptybase.filename().string().size(), 6u);
+
+    // Empty path doesn't exist and cannot be created
+    EXPECT_THROW(rcpputils::fs::create_temp_directory("basename", std::filesystem::path()),
+      std::system_error);
+
+    // With the template string XXXXXX already in the name, it will still be there, the unique
+    // portion is appended to the end.
+    const auto tmpdir_template_in_name_std = rcpputils::fs::create_temp_directory("base_XXXXXX");
+    rcpputils::fs::path tmpdir_template_in_name(tmpdir_template_in_name_std.c_str());
+    EXPECT_TRUE(tmpdir_template_in_name.exists());
+    EXPECT_TRUE(tmpdir_template_in_name.is_directory());
+    // On Linux, it will not replace the base_name Xs, only the final 6 that the function appends.
+    // On OSX, it will replace _all_ trailing Xs.
+    // Either way, the result is unique, the exact value doesn't matter.
+    EXPECT_EQ(tmpdir_template_in_name.filename().string().rfind("base_", 0), 0u);
+  }
+}
+
 TEST(TestFilesystemHelper, equal_operators)
 {
   path a{"foo"};

--- a/test/test_filesystem_helper.cpp
+++ b/test/test_filesystem_helper.cpp
@@ -308,7 +308,8 @@ TEST(TestFilesystemHelper, filesystem_manipulation)
   EXPECT_TRUE(rcpputils::fs::remove(dir));
   EXPECT_FALSE(rcpputils::fs::exists(file));
   EXPECT_FALSE(rcpputils::fs::exists(dir));
-  auto temp_dir = rcpputils::fs::temp_directory_path();
+  auto temp_dir_std = rcpputils::fs::temp_directory_path();
+  rcpputils::fs::path temp_dir = rcpputils::fs::path(temp_dir_std.c_str());
   temp_dir = temp_dir / "rcpputils" / "test_folder";
   EXPECT_FALSE(rcpputils::fs::exists(temp_dir));
   EXPECT_TRUE(rcpputils::fs::create_directories(temp_dir));
@@ -452,7 +453,10 @@ TEST(TestFilesystemHelper, create_temp_directory)
   {
     const std::string basename = "test_base_name";
 
-    const auto tmpdir1 = rcpputils::fs::create_temp_directory(basename);
+    const auto tmpdir1_std = rcpputils::fs::create_temp_directory(basename);
+    rcpputils::fs::path tmpdir1(tmpdir1_std.c_str());
+
+
     EXPECT_TRUE(tmpdir1.exists());
     EXPECT_TRUE(tmpdir1.is_directory());
 
@@ -464,7 +468,8 @@ TEST(TestFilesystemHelper, create_temp_directory)
     EXPECT_TRUE(rcpputils::fs::exists(tmp_file));
     EXPECT_TRUE(rcpputils::fs::is_regular_file(tmp_file));
 
-    const auto tmpdir2 = rcpputils::fs::create_temp_directory(basename);
+    const auto tmpdir2_std = rcpputils::fs::create_temp_directory(basename);
+    rcpputils::fs::path tmpdir2(tmpdir2_std.c_str());
     EXPECT_TRUE(tmpdir2.exists());
     EXPECT_TRUE(tmpdir2.is_directory());
 
@@ -486,7 +491,11 @@ TEST(TestFilesystemHelper, create_temp_directory)
   // newly created paths
   {
     const auto new_relative = rcpputils::fs::current_path() / "child1" / "child2";
-    const auto tmpdir = rcpputils::fs::create_temp_directory("base_name", new_relative);
+    const auto tmpdir_std = rcpputils::fs::create_temp_directory(
+      "base_name",
+      std::filesystem::path(new_relative.string()));
+    rcpputils::fs::path tmpdir(tmpdir_std.c_str());
+
     EXPECT_TRUE(tmpdir.exists());
     EXPECT_TRUE(tmpdir.is_directory());
     EXPECT_TRUE(rcpputils::fs::remove_all(tmpdir));
@@ -499,11 +508,13 @@ TEST(TestFilesystemHelper, create_temp_directory)
     EXPECT_EQ(tmpdir_emptybase.filename().string().size(), 6u);
 
     // Empty path doesn't exist and cannot be created
-    EXPECT_THROW(rcpputils::fs::create_temp_directory("basename", path()), std::system_error);
+    EXPECT_THROW(rcpputils::fs::create_temp_directory("basename", std::filesystem::path()),
+      std::system_error);
 
     // With the template string XXXXXX already in the name, it will still be there, the unique
     // portion is appended to the end.
-    const auto tmpdir_template_in_name = rcpputils::fs::create_temp_directory("base_XXXXXX");
+    const auto tmpdir_template_in_name_std = rcpputils::fs::create_temp_directory("base_XXXXXX");
+    rcpputils::fs::path tmpdir_template_in_name(tmpdir_template_in_name_std.c_str());
     EXPECT_TRUE(tmpdir_template_in_name.exists());
     EXPECT_TRUE(tmpdir_template_in_name.is_directory());
     // On Linux, it will not replace the base_name Xs, only the final 6 that the function appends.


### PR DESCRIPTION
Related to this comment https://github.com/ros2/rcpputils/pull/196#discussion_r1671225326

update `create_temp_directory` and `temp_directory_path` to use `std::filesystem::path`

Related PRs
 - https://github.com/ros2/rcl_logging/pull/117
 - https://github.com/ros2/rosbag2/pull/1740