### PR TITLE
Clear the rcutils error when throwing an exception.

### DIFF
--- a/src/shared_library.cpp
+++ b/src/shared_library.cpp
@@ -30,6 +30,7 @@ SharedLibrary::SharedLibrary(const std::string & library_path)
     rcutils_get_default_allocator());
   if (ret != RCUTILS_RET_OK) {
     if (ret == RCUTILS_RET_BAD_ALLOC) {
+      rcutils_reset_error();
       throw std::bad_alloc();
     } else {
       std::string rcutils_error_str(rcutils_get_error_string().str);


### PR DESCRIPTION
All of the rest of the code here does it, so throwing a std::bad_alloc should do the same.