### PR TITLE
add thread naming utilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,8 @@ add_library(${PROJECT_NAME}
   src/filesystem_helper.cpp
   src/find_library.cpp
   src/process.cpp
-  src/shared_library.cpp)
+  src/shared_library.cpp
+  src/thread_name.cpp)
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
@@ -94,6 +95,9 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_asserts_debug test/test_asserts.cpp)
   target_link_libraries(test_asserts_debug ${PROJECT_NAME})
+
+  ament_add_gtest(test_thread_name test/test_thread_name.cpp)
+  target_link_libraries(test_thread_name ${PROJECT_NAME})
 
   ament_add_gtest(test_thread_safety_annotations test/test_thread_safety_annotations.cpp)
   target_link_libraries(test_thread_safety_annotations ${PROJECT_NAME})

--- a/include/rcpputils/thread_name.hpp
+++ b/include/rcpputils/thread_name.hpp
@@ -17,6 +17,8 @@
 
 #include <string>
 
+#include "rcpputils/visibility_control.hpp"
+
 namespace rcpputils
 {
 
@@ -25,14 +27,14 @@ namespace rcpputils
  * \param[in] name the name to set for the current thread. May be truncated depending on platform.
  * \throws std::system_error if the thread name cannot be set.
  */
-void set_thread_name(const std::string & name);
+RCPPUTILS_PUBLIC void set_thread_name(const std::string & name);
 
 /// Get the current thread name
 /**
  * \return the name of the current thread.
  * \throws std::system_error if the thread name cannot be retrieved.
  */
-std::string get_thread_name();
+RCPPUTILS_PUBLIC std::string get_thread_name();
 
 }  // namespace rcpputils
 

--- a/include/rcpputils/thread_name.hpp
+++ b/include/rcpputils/thread_name.hpp
@@ -1,0 +1,39 @@
+// Copyright 2025 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCPPUTILS__THREAD_NAME_HPP_
+#define RCPPUTILS__THREAD_NAME_HPP_
+
+#include <string>
+
+namespace rcpputils
+{
+
+/// Set the current thread name
+/**
+ * \param[in] name the name to set for the current thread. May be truncated depending on platform.
+ * \throws std::system_error if the thread name cannot be set.
+ */
+void set_thread_name(const std::string & name);
+
+/// Get the current thread name
+/**
+ * \return the name of the current thread.
+ * \throws std::system_error if the thread name cannot be retrieved.
+ */
+std::string get_thread_name();
+
+}  // namespace rcpputils
+
+#endif  // RCPPUTILS__THREAD_NAME_HPP_

--- a/src/thread_name.cpp
+++ b/src/thread_name.cpp
@@ -22,6 +22,8 @@
 #include <pthread.h>
 #endif  // defined(_WIN32)
 
+#include <cstddef>
+#include <string>
 #include <system_error>
 
 namespace rcpputils
@@ -53,9 +55,9 @@ void set_thread_name_windows(const std::string & name)
 
 // This includes the null terminator
 #if defined(__APPLE__)
-constexpr size_t MAXTHREADNAMESIZE = 64;
+constexpr std::size_t MAXTHREADNAMESIZE = 64;
 #else  // posix
-constexpr size_t MAXTHREADNAMESIZE = 16;
+constexpr std::size_t MAXTHREADNAMESIZE = 16;
 #endif  // defined(__APPLE__)
 
 void set_thread_name_posix(const std::string & name)

--- a/src/thread_name.cpp
+++ b/src/thread_name.cpp
@@ -1,0 +1,122 @@
+// Copyright 2025 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rcpputils/thread_name.hpp"
+
+#if defined(_WIN32)
+#include <windows.h>
+#include <sstream>
+#include <vector>
+#else  // posix and apple
+#include <pthread.h>
+#endif  // defined(_WIN32)
+
+#include <system_error>
+
+namespace rcpputils
+{
+
+#if defined(_WIN32)
+void set_thread_name_windows(const std::string & name)
+{
+  int wchars_num = MultiByteToWideChar(CP_UTF8, 0, thread_name, -1, nullptr, 0);
+  if (wchars_num == 0) {
+    DWORD error_code = GetLastError();
+    std::error_code error_code_obj(error_code, std::system_category());
+    throw std::system_error(error_code_obj, "Failed to convert thread name to wide characters");
+  }
+  std::vector<wchar_t> wstr(wchars_num);
+  if (!MultiByteToWideChar(CP_UTF8, 0, thread_name, -1, wstr.data(), wchars_num)) {
+    DWORD error_code = GetLastError();
+    std::error_code error_code_obj(error_code, std::system_category());
+    throw std::system_error(error_code_obj, "Failed to convert thread name to wide characters");
+  }
+  // This will only work on Windows 10 and above.
+  auto result = SetThreadDescription(GetCurrentThread(), wstr.data());
+  if (FAILED(result)) {
+    std::error_code error_code(result, std::system_category());
+    throw std::system_error(error_code, "Failed to set thread description");
+  }
+}
+#else
+
+// This includes the null terminator
+#if defined(__APPLE__)
+constexpr size_t MAXTHREADNAMESIZE = 64;
+#else  // posix
+constexpr size_t MAXTHREADNAMESIZE = 16;
+#endif  // defined(__APPLE__)
+
+void set_thread_name_posix(const std::string & name)
+{
+  const char * thread_name;
+  // Truncate name to maximum length supported by pthread_setname_np
+  // leaving one character for the null terminator
+  // otherwise pthread_setname_np will return an ERANGE error
+  if (name.size() > MAXTHREADNAMESIZE - 1) {
+    std::string truncated_name = name.substr(0, MAXTHREADNAMESIZE - 1);
+    thread_name = truncated_name.c_str();
+  } else {
+    thread_name = name.c_str();
+  }
+#if defined(__APPLE__)
+  int rc = pthread_setname_np(thread_name);
+#else  // posix
+  int rc = pthread_setname_np(pthread_self(), thread_name);
+#endif  // defined(__APPLE__)
+  if (rc != 0) {
+    std::error_code error_code(rc, std::system_category());
+    throw std::system_error(error_code, "Failed to set thread name");
+  }
+}
+
+#endif  // defined(_WIN32)
+
+void set_thread_name(const std::string & name)
+{
+#if defined(_WIN32)
+  set_thread_name_windows(name);
+#else
+  set_thread_name_posix(name);
+#endif  // defined(_WIN32)
+}
+
+std::string get_thread_name()
+{
+  std::string name;
+#if defined(_WIN32)
+  // This will only work on Windows 10 and above.
+  PWSTR thread_description;
+  auto result = GetThreadDescription(GetCurrentThread(), &thread_description);
+  if (FAILED(result)) {
+    std::error_code error_code(result, std::system_category());
+    throw std::system_error(error_code, "Failed to get thread name");
+  }
+  std::wstringstream wss;
+  wss << thread_description;
+  name = wss.str();
+  LocalFree(thread_description);
+#else  // posix and apple
+  char thread_name[MAXTHREADNAMESIZE];  // This includes the null terminator
+  int rc = pthread_getname_np(pthread_self(), thread_name, sizeof(thread_name));
+  if (rc != 0) {
+    std::error_code error_code(rc, std::system_category());
+    throw std::system_error(error_code, "Failed to get thread name");
+  }
+  name = std::string(thread_name);
+#endif
+  return name;
+}
+
+}  // namespace rcpputils

--- a/src/thread_name.cpp
+++ b/src/thread_name.cpp
@@ -16,7 +16,6 @@
 
 #if defined(_WIN32)
 #include <windows.h>
-#include <sstream>
 #include <vector>
 #else  // posix and apple
 #include <pthread.h>
@@ -32,23 +31,24 @@ namespace rcpputils
 #if defined(_WIN32)
 void set_thread_name_windows(const std::string & name)
 {
-  int wchars_num = MultiByteToWideChar(CP_UTF8, 0, thread_name, -1, nullptr, 0);
-  if (wchars_num == 0) {
-    DWORD error_code = GetLastError();
-    std::error_code error_code_obj(error_code, std::system_category());
+  int wchars_num = MultiByteToWideChar(CP_UTF8, 0, name.c_str(), -1, nullptr, 0);
+  bool conversion_failed = wchars_num == 0;
+  if (!conversion_failed) {
+      std::vector<wchar_t> wstr(wchars_num);
+      auto ret = MultiByteToWideChar(CP_UTF8, 0, name.c_str(), -1, wstr.data(), wchars_num);
+      bool conversion_failed = ret == 0;
+      if (!conversion_failed) {
+          // This will only work on Windows 10 and above.
+          auto result = SetThreadDescription(GetCurrentThread(), wstr.data());
+          if (FAILED(result)) {
+              std::error_code error_code(result, std::system_category());
+              throw std::system_error(error_code, "Failed to set thread description");
+          }
+      }
+   }
+  if (conversion_failed) {
+    std::error_code error_code_obj(GetLastError(), std::system_category());
     throw std::system_error(error_code_obj, "Failed to convert thread name to wide characters");
-  }
-  std::vector<wchar_t> wstr(wchars_num);
-  if (!MultiByteToWideChar(CP_UTF8, 0, thread_name, -1, wstr.data(), wchars_num)) {
-    DWORD error_code = GetLastError();
-    std::error_code error_code_obj(error_code, std::system_category());
-    throw std::system_error(error_code_obj, "Failed to convert thread name to wide characters");
-  }
-  // This will only work on Windows 10 and above.
-  auto result = SetThreadDescription(GetCurrentThread(), wstr.data());
-  if (FAILED(result)) {
-    std::error_code error_code(result, std::system_category());
-    throw std::system_error(error_code, "Failed to set thread description");
   }
 }
 #else
@@ -106,10 +106,19 @@ std::string get_thread_name()
     std::error_code error_code(result, std::system_category());
     throw std::system_error(error_code, "Failed to get thread name");
   }
-  std::wstringstream wss;
-  wss << thread_description;
-  name = wss.str();
+  int size_needed = WideCharToMultiByte(CP_UTF8, 0, thread_description, -1, nullptr, 0, nullptr, nullptr);
+  bool conversion_failed = size_needed == 0;
+  if (!conversion_failed) {
+      name = std::string(size_needed - 1, 0);
+      auto ret = WideCharToMultiByte(CP_UTF8, 0, thread_description, -1, &name[0], size_needed, nullptr, nullptr);
+      conversion_failed = ret == 0;
+  }
   LocalFree(thread_description);
+  if (conversion_failed) {
+      DWORD error_code = GetLastError();
+      std::error_code error_code_obj(error_code, std::system_category());
+      throw std::system_error(error_code_obj, "Failed to convert thread name from wide characters");
+  }
 #else  // posix and apple
   char thread_name[MAXTHREADNAMESIZE];  // This includes the null terminator
   int rc = pthread_getname_np(pthread_self(), thread_name, sizeof(thread_name));

--- a/src/thread_name.cpp
+++ b/src/thread_name.cpp
@@ -34,18 +34,18 @@ void set_thread_name_windows(const std::string & name)
   int wchars_num = MultiByteToWideChar(CP_UTF8, 0, name.c_str(), -1, nullptr, 0);
   bool conversion_failed = wchars_num == 0;
   if (!conversion_failed) {
-      std::vector<wchar_t> wstr(wchars_num);
-      auto ret = MultiByteToWideChar(CP_UTF8, 0, name.c_str(), -1, wstr.data(), wchars_num);
-      bool conversion_failed = ret == 0;
-      if (!conversion_failed) {
+    std::vector<wchar_t> wstr(wchars_num);
+    auto ret = MultiByteToWideChar(CP_UTF8, 0, name.c_str(), -1, wstr.data(), wchars_num);
+    bool conversion_failed = ret == 0;
+    if (!conversion_failed) {
           // This will only work on Windows 10 and above.
-          auto result = SetThreadDescription(GetCurrentThread(), wstr.data());
-          if (FAILED(result)) {
-              std::error_code error_code(result, std::system_category());
-              throw std::system_error(error_code, "Failed to set thread description");
-          }
+      auto result = SetThreadDescription(GetCurrentThread(), wstr.data());
+      if (FAILED(result)) {
+        std::error_code error_code(result, std::system_category());
+        throw std::system_error(error_code, "Failed to set thread description");
       }
-   }
+    }
+  }
   if (conversion_failed) {
     std::error_code error_code_obj(GetLastError(), std::system_category());
     throw std::system_error(error_code_obj, "Failed to convert thread name to wide characters");
@@ -62,7 +62,7 @@ constexpr std::size_t MAXTHREADNAMESIZE = 16;
 
 void set_thread_name_posix(const std::string & name)
 {
-  std::string truncated_name; // At this scope to keep lifetime long enough
+  std::string truncated_name;  // At this scope to keep lifetime long enough
   const char * thread_name_ptr;
   // Truncate name to maximum length supported by pthread_setname_np
   // leaving one character for the null terminator
@@ -106,18 +106,20 @@ std::string get_thread_name()
     std::error_code error_code(result, std::system_category());
     throw std::system_error(error_code, "Failed to get thread name");
   }
-  int size_needed = WideCharToMultiByte(CP_UTF8, 0, thread_description, -1, nullptr, 0, nullptr, nullptr);
+  int size_needed = WideCharToMultiByte(CP_UTF8, 0, thread_description, -1, nullptr, 0, nullptr,
+      nullptr);
   bool conversion_failed = size_needed == 0;
   if (!conversion_failed) {
-      name = std::string(size_needed - 1, 0);
-      auto ret = WideCharToMultiByte(CP_UTF8, 0, thread_description, -1, &name[0], size_needed, nullptr, nullptr);
-      conversion_failed = ret == 0;
+    name = std::string(size_needed - 1, 0);
+    auto ret = WideCharToMultiByte(CP_UTF8, 0, thread_description, -1, &name[0], size_needed,
+        nullptr, nullptr);
+    conversion_failed = ret == 0;
   }
   LocalFree(thread_description);
   if (conversion_failed) {
-      DWORD error_code = GetLastError();
-      std::error_code error_code_obj(error_code, std::system_category());
-      throw std::system_error(error_code_obj, "Failed to convert thread name from wide characters");
+    DWORD error_code = GetLastError();
+    std::error_code error_code_obj(error_code, std::system_category());
+    throw std::system_error(error_code_obj, "Failed to convert thread name from wide characters");
   }
 #else  // posix and apple
   char thread_name[MAXTHREADNAMESIZE];  // This includes the null terminator

--- a/src/thread_name.cpp
+++ b/src/thread_name.cpp
@@ -62,20 +62,19 @@ constexpr std::size_t MAXTHREADNAMESIZE = 16;
 
 void set_thread_name_posix(const std::string & name)
 {
-  const char * thread_name;
+  std::string thread_name;
   // Truncate name to maximum length supported by pthread_setname_np
   // leaving one character for the null terminator
   // otherwise pthread_setname_np will return an ERANGE error
   if (name.size() > MAXTHREADNAMESIZE - 1) {
-    std::string truncated_name = name.substr(0, MAXTHREADNAMESIZE - 1);
-    thread_name = truncated_name.c_str();
+    thread_name = name.substr(0, MAXTHREADNAMESIZE - 1);
   } else {
-    thread_name = name.c_str();
+    thread_name = name;
   }
 #if defined(__APPLE__)
-  int rc = pthread_setname_np(thread_name);
+  int rc = pthread_setname_np(thread_name.c_str());
 #else  // posix
-  int rc = pthread_setname_np(pthread_self(), thread_name);
+  int rc = pthread_setname_np(pthread_self(), thread_name.c_str());
 #endif  // defined(__APPLE__)
   if (rc != 0) {
     std::error_code error_code(rc, std::system_category());

--- a/src/thread_name.cpp
+++ b/src/thread_name.cpp
@@ -62,19 +62,21 @@ constexpr std::size_t MAXTHREADNAMESIZE = 16;
 
 void set_thread_name_posix(const std::string & name)
 {
-  std::string thread_name;
+  std::string truncated_name; // At this scope to keep lifetime long enough
+  const char * thread_name_ptr;
   // Truncate name to maximum length supported by pthread_setname_np
   // leaving one character for the null terminator
   // otherwise pthread_setname_np will return an ERANGE error
   if (name.size() > MAXTHREADNAMESIZE - 1) {
-    thread_name = name.substr(0, MAXTHREADNAMESIZE - 1);
+    truncated_name = name.substr(0, MAXTHREADNAMESIZE - 1);
+    thread_name_ptr = truncated_name.c_str();
   } else {
-    thread_name = name;
+    thread_name_ptr = name.c_str();
   }
 #if defined(__APPLE__)
-  int rc = pthread_setname_np(thread_name.c_str());
+  int rc = pthread_setname_np(thread_name_ptr);
 #else  // posix
-  int rc = pthread_setname_np(pthread_self(), thread_name.c_str());
+  int rc = pthread_setname_np(pthread_self(), thread_name_ptr);
 #endif  // defined(__APPLE__)
   if (rc != 0) {
     std::error_code error_code(rc, std::system_category());

--- a/test/test_thread_name.cpp
+++ b/test/test_thread_name.cpp
@@ -1,0 +1,48 @@
+// Copyright 2025 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gtest/gtest.h"
+
+#include "rcpputils/thread_name.hpp"
+
+TEST(TestOsThread, set_thread_name) {
+  rcpputils::set_thread_name("test_thread");
+
+  EXPECT_STREQ("test_thread", rcpputils::get_thread_name().c_str());
+}
+
+#if defined(_WIN32)
+TEST(TestOsThread, no_truncation_on_windows) {
+  rcpputils::set_thread_name("0123456789abcdef");
+
+  // Should be unaffected by truncation
+  EXPECT_STREQ("0123456789abcdef", rcpputils::get_thread_name().c_str());
+}
+#elif defined(__APPLE__)
+TEST(TestOsThread, truncation_on_apple) {
+  rcpputils::set_thread_name(
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+
+  // Should be 63 characters and then the null terminator
+  EXPECT_STREQ("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde",
+    rcpputils::get_thread_name().c_str());
+}
+#else  // posix
+TEST(TestOsThread, truncation_on_posix) {
+  rcpputils::set_thread_name("0123456789abcdef");
+
+  // Should be 15 characters and then the null terminator
+  EXPECT_STREQ("0123456789abcde", rcpputils::get_thread_name().c_str());
+}
+#endif


### PR DESCRIPTION
## Description
Moved thread naming utilities from https://github.com/ros2/rclcpp/pull/2871.

Fixes https://github.com/ros2/rclcpp/issues/2818

### Is this user-facing behavior change?
No, just new interfaces.

### Did you use Generative AI?
Yes. Cursor autocomplete.

### Additional Information
