### PR TITLE
Remove unnecessary dependencies from rcpputils.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,14 +51,11 @@ ament_export_targets(${PROJECT_NAME})
 ament_export_dependencies(rcutils)
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_gtest REQUIRED)
-
   find_package(ament_cmake_copyright REQUIRED)
   find_package(ament_cmake_cppcheck REQUIRED)
   find_package(ament_cmake_cpplint REQUIRED)
-  find_package(ament_cmake_flake8 REQUIRED)
+  find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_cmake_lint_cmake REQUIRED)
-  find_package(ament_cmake_pep257 REQUIRED)
   find_package(ament_cmake_uncrustify REQUIRED)
   find_package(ament_cmake_xmllint REQUIRED)
 
@@ -73,9 +70,7 @@ if(BUILD_TESTING)
     LANGUAGE c++
   )
   ament_cpplint(EXCLUDE ${_linter_excludes})
-  ament_flake8(EXCLUDE ${_linter_excludes})
   ament_lint_cmake()
-  ament_pep257(EXCLUDE ${_linter_excludes})
   ament_uncrustify(
     EXCLUDE ${_linter_excludes}
     LANGUAGE c++

--- a/package.xml
+++ b/package.xml
@@ -21,15 +21,11 @@
 
   <depend>rcutils</depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
-
-  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_copyright</test_depend>
   <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_cmake_cpplint</test_depend>
-  <test_depend>ament_cmake_flake8</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
-  <test_depend>ament_cmake_pep257</test_depend>
   <test_depend>ament_cmake_uncrustify</test_depend>
   <test_depend>ament_cmake_xmllint</test_depend>
 


### PR DESCRIPTION
## Description

rcpputils doesn't need to have dependencies on python tests.

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

No.

### Additional Information

N/A