### PR TITLE
Remove -Werror from Clang compile options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ if(BUILD_TESTING)
   ament_xmllint()
 
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-Wthread-safety -Werror)
+    add_compile_options(-Wthread-safety)
   endif()
 
   ament_add_gtest(test_asserts_ndebug test/test_asserts.cpp)


### PR DESCRIPTION
## Description

While useful, in my opinion it's not appropriate to set `-Werror` the `CMakeLists.txt`, instead allowing the user to set it if they wish, or setting it during CI if you want to catch warnings during testing.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

This is the warning that was being turned into an error by `-Werror`:

```
/Users/wjwwood/ros2_ws/src/ros2/rcpputils/test/test_thread_safety_annotations.cpp:57:12: warning: 'guarded_by' attribute requires arguments whose type is annotated with 'capability' attribute; type here is 'std::mutex' [-Wthread-safety-attributes]
   57 |   int data RCPPUTILS_TSA_GUARDED_BY(mu);
      |            ^
/Users/wjwwood/ros2_ws/src/ros2/rcpputils/include/rcpputils/thread_safety_annotations.hpp:93:46: note: expanded from macro 'RCPPUTILS_TSA_GUARDED_BY'
   93 |   RCPPUTILS_THREAD_ANNOTATION_ATTRIBUTE_IMPL(guarded_by(x))
      |                                              ^
/Users/wjwwood/ros2_ws/src/ros2/rcpputils/test/test_thread_safety_annotations.cpp:59:14: warning: 'requires_capability' attribute requires arguments whose type is annotated with 'capability' attribute; type here is 'std::mutex' [-Wthread-safety-attributes]
   59 |   int incr() RCPPUTILS_TSA_REQUIRES(mu) {
      |              ^
/Users/wjwwood/ros2_ws/src/ros2/rcpputils/include/rcpputils/thread_safety_annotations.hpp:141:46: note: expanded from macro 'RCPPUTILS_TSA_REQUIRES'
  141 |   RCPPUTILS_THREAD_ANNOTATION_ATTRIBUTE_IMPL(requires_capability(__VA_ARGS__))
      |                                              ^
/Users/wjwwood/ros2_ws/src/ros2/rcpputils/test/test_thread_safety_annotations.cpp:152:12: warning: reading variable 'data' requires holding mutex 'mu' [-Wthread-safety-analysis]
  152 |     return data;
      |            ^
/Users/wjwwood/ros2_ws/src/ros2/rcpputils/test/test_thread_safety_annotations.cpp:192:11: warning: writing variable 'data' requires holding mutex 'guarded.mu' exclusively [-Wthread-safety-analysis]
  192 |   guarded.data++;
      |           ^
/Users/wjwwood/ros2_ws/src/ros2/rcpputils/test/test_thread_safety_annotations.cpp:198:13: warning: writing variable 'data' requires holding mutex 'guarded.mu' exclusively [-Wthread-safety-analysis]
  198 |     guarded.data++;
      |             ^
/Users/wjwwood/ros2_ws/src/ros2/rcpputils/test/test_thread_safety_annotations.cpp:199:13: warning: calling function 'incr' requires holding mutex 'guarded.mu' exclusively [-Wthread-safety-analysis]
  199 |     guarded.incr();
      |             ^
6 warnings generated.
```

I'll perhaps fix that in a follow up pr.